### PR TITLE
Require range optimization to apply

### DIFF
--- a/.github/workflows/buildandrun.yml
+++ b/.github/workflows/buildandrun.yml
@@ -17,7 +17,5 @@ jobs:
       - name: Deploy MySQL
         run: scripts/dbdeployer_install_8028.sh
 
-      - name: Build and Run
-        run: go build ./cmd/spirit
-             ~/sandboxes/msb_8_0_28/use test -e "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, b INT NOT NULL, c INT NOT NULL)"
-             ./cmd/spirit/spirit -h "127.0.0.1:8028" --database=test --table=stock
+      - name: Build and Run Spirit
+        run: scripts/build_and_run.sh

--- a/.github/workflows/buildandrun.yml
+++ b/.github/workflows/buildandrun.yml
@@ -1,0 +1,23 @@
+name: MySQL 8.0 Build and Run
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy MySQL
+        run: scripts/dbdeployer_install_8028.sh
+
+      - name: Build and Run
+        run: go build ./cmd/spirit
+        ~/sandboxes/msb_8_0_28/use test -e "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, b INT NOT NULL, c INT NOT NULL)"
+        ./cmd/spirit/spirit -h "127.0.0.1:8028" --database=test --table=stock

--- a/.github/workflows/buildandrun.yml
+++ b/.github/workflows/buildandrun.yml
@@ -19,5 +19,5 @@ jobs:
 
       - name: Build and Run
         run: go build ./cmd/spirit
-        ~/sandboxes/msb_8_0_28/use test -e "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, b INT NOT NULL, c INT NOT NULL)"
-        ./cmd/spirit/spirit -h "127.0.0.1:8028" --database=test --table=stock
+             ~/sandboxes/msb_8_0_28/use test -e "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, b INT NOT NULL, c INT NOT NULL)"
+             ./cmd/spirit/spirit -h "127.0.0.1:8028" --database=test --table=stock

--- a/pkg/check/dropadd.go
+++ b/pkg/check/dropadd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/siddontang/loggers"
 )
 

--- a/pkg/check/dropadd_test.go
+++ b/pkg/check/dropadd_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/table"
-	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/check/foreignkey.go
+++ b/pkg/check/foreignkey.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/siddontang/loggers"
 )
 

--- a/pkg/check/foreignkey_test.go
+++ b/pkg/check/foreignkey_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cashapp/spirit/pkg/table"
 	"github.com/cashapp/spirit/pkg/testutils"
-	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/check/primarykey.go
+++ b/pkg/check/primarykey.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/siddontang/loggers"
 )
 

--- a/pkg/check/primarykey_test.go
+++ b/pkg/check/primarykey_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/table"
-	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/check/rename.go
+++ b/pkg/check/rename.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/siddontang/loggers"
 )
 

--- a/pkg/check/triggers.go
+++ b/pkg/check/triggers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/siddontang/loggers"
 )
 

--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -97,6 +97,8 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	ops = append(ops, fmt.Sprintf("%s=%s", "time_zone", url.QueryEscape(`"+00:00"`)))
 	ops = append(ops, fmt.Sprintf("%s=%s", "innodb_lock_wait_timeout", url.QueryEscape(fmt.Sprint(config.InnodbLockWaitTimeout))))
 	ops = append(ops, fmt.Sprintf("%s=%s", "lock_wait_timeout", url.QueryEscape(fmt.Sprint(config.LockWaitTimeout))))
+	ops = append(ops, fmt.Sprintf("%s=%s", "range_optimizer_max_mem_size", url.QueryEscape(fmt.Sprint(config.RangeOptimizerMaxMemSize))))
+
 	if config.Aurora20Compatible {
 		ops = append(ops, fmt.Sprintf("%s=%s", "tx_isolation", url.QueryEscape(`"read-committed"`))) // Aurora 2.0
 	} else {

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -13,25 +13,25 @@ func TestNewDSN(t *testing.T) {
 	dsn := "root:password@tcp(127.0.0.1:3306)/test"
 	resp, err := newDSN(dsn, NewDBConfig())
 	assert.NoError(t, err)
-	assert.Equal(t, "root:password@tcp(127.0.0.1:3306)/test?sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
+	assert.Equal(t, "root:password@tcp(127.0.0.1:3306)/test?sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&range_optimizer_max_mem_size=0&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
 
 	// Also without TLS options
 	dsn = "root:password@tcp(mydbhost.internal:3306)/test"
 	resp, err = newDSN(dsn, NewDBConfig())
 	assert.NoError(t, err)
-	assert.Equal(t, "root:password@tcp(mydbhost.internal:3306)/test?sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp) // unchanged
+	assert.Equal(t, "root:password@tcp(mydbhost.internal:3306)/test?sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&range_optimizer_max_mem_size=0&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp) // unchanged
 
 	// However, if it is RDS - it will be changed.
 	dsn = "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com)/test"
 	resp, err = newDSN(dsn, NewDBConfig())
 	assert.NoError(t, err)
-	assert.Equal(t, "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com)/test?tls=rds&sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
+	assert.Equal(t, "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com)/test?tls=rds&sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&range_optimizer_max_mem_size=0&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
 
 	// This is with optional port too
 	dsn = "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com:12345)/test"
 	resp, err = newDSN(dsn, NewDBConfig())
 	assert.NoError(t, err)
-	assert.Equal(t, "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com:12345)/test?tls=rds&sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
+	assert.Equal(t, "root:password@tcp(tern-001.cluster-ro-ckxxxxxxvm.us-west-2.rds.amazonaws.com:12345)/test?tls=rds&sql_mode=%22%22&time_zone=%22%2B00%3A00%22&innodb_lock_wait_timeout=3&lock_wait_timeout=30&range_optimizer_max_mem_size=0&transaction_isolation=%22read-committed%22&charset=binary&collation=binary", resp)
 
 	// Invalid DSN, can't parse.
 	dsn = "invalid"

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -24,19 +24,21 @@ const (
 )
 
 type DBConfig struct {
-	LockWaitTimeout       int
-	InnodbLockWaitTimeout int
-	MaxRetries            int
-	MaxOpenConnections    int
-	Aurora20Compatible    bool // use tx_isolation instead of transaction_isolation
+	LockWaitTimeout          int
+	InnodbLockWaitTimeout    int
+	MaxRetries               int
+	MaxOpenConnections       int
+	Aurora20Compatible       bool // use tx_isolation instead of transaction_isolation
+	RangeOptimizerMaxMemSize int64
 }
 
 func NewDBConfig() *DBConfig {
 	return &DBConfig{
-		LockWaitTimeout:       30,
-		InnodbLockWaitTimeout: 3,
-		MaxRetries:            5,
-		MaxOpenConnections:    32, // default is high for historical tests
+		LockWaitTimeout:          30,
+		InnodbLockWaitTimeout:    3,
+		MaxRetries:               5,
+		MaxOpenConnections:       32, // default is high for historical tests. It's overwritten by the user threads count + 2 for headroom.
+		RangeOptimizerMaxMemSize: 0,  // default is 8M, we set to unlimited. Not user configurable (may reconsider in the future).
 	}
 }
 
@@ -121,8 +123,13 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, ignoreDupKeyWarnings 
 					} else if code == errCapacityExceeded {
 						// "Memory capacity of 8388608 bytes for 'range_optimizer_max_mem_size' exceeded.
 						// Range optimization was not done for this query."
-						// i.e. the query still executes it just doesn't optimize perfectly
-						continue
+						// i.e. the query can still execute, but it won't be efficient. Prior to
+						// https://github.com/cashapp/spirit/issues/239 we allowed this warning
+						// to be ignored. *However* if range optimization is disabled the query is going to
+						// tablescan, so it's better to just bail out and present a useful error message.
+						isFatal = true
+						err = fmt.Errorf("MySQL refused to optimize a statement because the value of 'range_optimizer_max_mem_size' is too low. Please decrease the target-chunk-time, or increase the value of 'range_optimizer_max_mem_size'")
+						return
 					} else {
 						isFatal = true
 						err = fmt.Errorf("unsafe warning: %s", message)

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cashapp/spirit/pkg/dbconn"
 	"github.com/cashapp/spirit/pkg/testutils"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	mysql2 "github.com/go-sql-driver/mysql"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestReplClient(t *testing.T) {
-	db, err := sql.Open("mysql", testutils.DSN())
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS replt1, replt2, _replt1_chkpnt")
@@ -58,7 +59,7 @@ func TestReplClient(t *testing.T) {
 }
 
 func TestReplClientComplex(t *testing.T) {
-	db, err := sql.Open("mysql", testutils.DSN())
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS replcomplext1, replcomplext2, _replcomplext1_chkpnt")
@@ -132,7 +133,7 @@ func TestReplClientComplex(t *testing.T) {
 }
 
 func TestReplClientResumeFromImpossible(t *testing.T) {
-	db, err := sql.Open("mysql", testutils.DSN())
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS replresumet1, replresumet2, _replresumet1_chkpnt")
@@ -190,7 +191,7 @@ func TestReplClientResumeFromPoint(t *testing.T) {
 }
 
 func TestReplClientOpts(t *testing.T) {
-	db, err := sql.Open("mysql", testutils.DSN())
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS replclientoptst1, replclientoptst2, _replclientoptst1_chkpnt")
@@ -244,7 +245,7 @@ func TestReplClientOpts(t *testing.T) {
 }
 
 func TestReplClientQueue(t *testing.T) {
-	db, err := sql.Open("mysql", testutils.DSN())
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS replqueuet1, replqueuet2, _replqueuet1_chkpnt")

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+go build ./cmd/spirit
+~/sandboxes/msb_8_0_28/use test -e "DROP TABLE IF EXISTS t1; CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, b INT NOT NULL, c INT NOT NULL)"
+./spirit --host "127.0.0.1:8028" --database=test --table=t1


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

This fixes https://github.com/cashapp/spirit/issues/239 in two ways:

1. It requires range optimization to apply, and escalates any warning where it hasn't applied to an error (providing some suggestions as well).
2. It sets the default to be unlimited memory for range optimization.

Thus because of (2) the condition (1) shouldn't apply, but since we may expose (2) as a configuration option in future it still makes sense to add both. I will wait for feedback on (2) since I don't want to rush and add configuration options. Since the concurrency of spirit is typically quite low, and this range optimizer memory limit didn't really exist prior to 5.7 anyway, it might be quite safe to just be unlimited for all cases.

(Based on the previous PR https://github.com/cashapp/spirit/pull/238 which has not yet merged. I can't really test one without the other).