### PR TITLE
fix checksum initial consistency

### DIFF
--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -153,14 +153,11 @@ func (c *CutOver) algorithmGhost(ctx context.Context) error {
 	if err := c.feed.Flush(ctx); err != nil {
 		return err
 	}
-	// These are safety measures to ensure that there are no pending changes.
+	// This is a safety measure to ensure that there are no pending changes.
 	// They are not known to return errors, but we check them anyway in case
 	// a change of logic is introduced.
 	if !c.feed.AllChangesFlushed() {
 		return errors.New("not all changes flushed, final flush might be broken")
-	}
-	if c.feed.GetDeltaLen() > 0 {
-		return fmt.Errorf("the changeset is not empty (%d), can not start cutover", c.feed.GetDeltaLen())
 	}
 	// Start the RENAME TABLE trx. This connection is
 	// described as C20 in the gh-ost docs.

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -128,9 +128,6 @@ func (c *CutOver) algorithmRenameUnderLock(ctx context.Context) error {
 	if !c.feed.AllChangesFlushed() {
 		return errors.New("not all changes flushed, final flush might be broken")
 	}
-	if c.feed.GetDeltaLen() > 0 {
-		return fmt.Errorf("the changeset is not empty (%d), can not start cutover", c.feed.GetDeltaLen())
-	}
 	oldName := fmt.Sprintf("_%s_old", c.table.TableName)
 	oldQuotedName := fmt.Sprintf("`%s`.`%s`", c.table.SchemaName, oldName)
 	renameStatement := fmt.Sprintf("RENAME TABLE %s TO %s, %s TO %s",

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -229,7 +229,7 @@ func TestReplClientOpts(t *testing.T) {
 	// Delete more than 10000 keys so the FLUSH has to run in chunks.
 	testutils.RunSQL(t, "DELETE FROM replclientoptst1 WHERE a BETWEEN 10 and 50000")
 	assert.NoError(t, client.BlockWait(context.TODO()))
-	assert.Equal(t, client.GetDeltaLen(), 49961)
+	assert.Equal(t, 49961, client.GetDeltaLen())
 	// Flush. We could use client.Flush() but for testing purposes lets use
 	// PeriodicFlush()
 	go client.StartPeriodicFlush(context.TODO(), 1*time.Second)
@@ -237,7 +237,7 @@ func TestReplClientOpts(t *testing.T) {
 	client.StopPeriodicFlush()
 	assert.Equal(t, 0, db.Stats().InUse) // all connections are returned
 
-	assert.Equal(t, client.GetDeltaLen(), 0)
+	assert.Equal(t, 0, client.GetDeltaLen())
 
 	// The binlog position should have changed.
 	assert.NotEqual(t, startingPos, client.GetBinlogApplyPosition())


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

This should fix https://github.com/cashapp/spirit/issues/248 (although I am unable to verify)

The checksum used a different method to cutover to produce consistency, which should have worked.. but might not have been as safe.

I've tried to simplify it and keep it the same. It now uses `Flush()` (ensure binlog reading is up to date + empty the binlog) instead of `BlockWait()` (only ensure binlog reading is up to date). `Flush()` is also modified to ensure there is at least a final-flush if `BlockWait()` is only called once (although this would be caught later by the safety checks).

I think the bug is caused by checksum code not calling `feed.AllChangesFlushed()`. It only calls `GetDeltaLen()`, which could still have other unapplied changes in memory. To simplify the API I've unified `feed.AllChangesFlushed()` to also check `GetDeltaLen()`.
