### PR TITLE
Add hidden --skip-checks option

### DIFF
--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -70,7 +70,7 @@ func RunChecks(ctx context.Context, r Resources, logger loggers.Advanced, scope 
 		for _, skip := range r.SkipChecks {
 			if skip == name {
 				logger.Warnf("Skipping check '%s'", name)
-				return nil
+				continue
 			}
 		}
 		err := check.callback(ctx, r, logger)

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -5,6 +5,7 @@ package check
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,16 +64,19 @@ func registerCheck(name string, callback func(context.Context, Resources, logger
 
 // RunChecks runs all checks that are registered for the given scope
 func RunChecks(ctx context.Context, r Resources, logger loggers.Advanced, scope ScopeFlag) error {
-check:
 	for name, check := range checks {
 		if check.scope&scope == 0 {
 			continue
 		}
+		skipped := false
 		for _, skip := range r.SkipChecks {
-			if skip == name {
+			if strings.EqualFold(skip, name) {
 				logger.Warnf("Skipping check '%s'", name)
-				continue check
+				skipped = true
 			}
+		}
+		if skipped {
+			continue
 		}
 		err := check.callback(ctx, r, logger)
 		if err != nil {

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -63,6 +63,7 @@ func registerCheck(name string, callback func(context.Context, Resources, logger
 
 // RunChecks runs all checks that are registered for the given scope
 func RunChecks(ctx context.Context, r Resources, logger loggers.Advanced, scope ScopeFlag) error {
+check:
 	for name, check := range checks {
 		if check.scope&scope == 0 {
 			continue
@@ -70,7 +71,7 @@ func RunChecks(ctx context.Context, r Resources, logger loggers.Advanced, scope 
 		for _, skip := range r.SkipChecks {
 			if skip == name {
 				logger.Warnf("Skipping check '%s'", name)
-				continue
+				continue check
 			}
 		}
 		err := check.callback(ctx, r, logger)

--- a/pkg/check/illegalClauseCheck.go
+++ b/pkg/check/illegalClauseCheck.go
@@ -1,0 +1,20 @@
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cashapp/spirit/pkg/utils"
+	"github.com/siddontang/loggers"
+)
+
+func init() {
+	registerCheck("illegalClause", illegalClauseCheck, ScopePreRun)
+}
+
+// illegalClauseCheck checks for the presence of specific, unsupported
+// clauses in the ALTER statement, such as ALGORITHM= and LOCK=.
+func illegalClauseCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {
+	sql := fmt.Sprintf("ALTER TABLE x.x %s", r.Alter)
+	return utils.AlterContainsUnsupportedClause(sql)
+}

--- a/pkg/check/illegalClauseCheck_test.go
+++ b/pkg/check/illegalClauseCheck_test.go
@@ -1,0 +1,44 @@
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cashapp/spirit/pkg/table"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIllegalClauseCheck(t *testing.T) {
+	r := Resources{
+		Table: &table.TableInfo{TableName: "test"},
+		Alter: "ALGORITHM=INPLACE",
+	}
+	err := illegalClauseCheck(context.Background(), r, logrus.New())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ALTER contains unsupported clause")
+
+	r = Resources{
+		Table: &table.TableInfo{TableName: "test"},
+		Alter: "ALGORITHM=INPLACE, LOCK=shared",
+	}
+	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ALTER contains unsupported clause")
+
+	r = Resources{
+		Table: &table.TableInfo{TableName: "test"},
+		Alter: "lock=none",
+	}
+	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ALTER contains unsupported clause")
+
+	r = Resources{
+		Table: &table.TableInfo{TableName: "test"},
+		Alter: "engine=innodb, algorithm=copy",
+	}
+	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ALTER contains unsupported clause")
+}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -41,6 +41,7 @@ func (m *Migration) Run() error {
 		// after release.
 		m.SkipChecks = append(m.SkipChecks, "version")
 	}
+
 	if err := migration.runChecks(context.TODO(), check.ScopePreRun); err != nil {
 		return err
 	}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -43,7 +43,7 @@ func TestE2ENullAlterEmpty(t *testing.T) {
 	migration.Checksum = true
 	migration.Table = "t1"
 	migration.Alter = "ENGINE=InnoDB"
-	migration.SkipPreRunChecks = true
+	migration.SkipChecks = append(migration.SkipChecks, "version")
 
 	err = migration.Run()
 	assert.NoError(t, err)
@@ -69,7 +69,7 @@ func TestMissingAlter(t *testing.T) {
 	migration.Checksum = true
 	migration.Table = "t1"
 	migration.Alter = ""
-	migration.SkipPreRunChecks = true
+	migration.SkipChecks = append(migration.SkipChecks, "version")
 
 	err = migration.Run()
 	assert.Error(t, err) // missing alter
@@ -96,7 +96,7 @@ func TestBadDatabaseCredentials(t *testing.T) {
 	migration.Checksum = true
 	migration.Table = "t1"
 	migration.Alter = "ENGINE=InnoDB"
-	migration.SkipPreRunChecks = true
+	migration.SkipChecks = append(migration.SkipChecks, "version")
 
 	err = migration.Run()
 	assert.Error(t, err)                                        // bad database credentials
@@ -124,7 +124,7 @@ func TestE2ENullAlter1Row(t *testing.T) {
 	migration.Checksum = true
 	migration.Table = "t1"
 	migration.Alter = "ENGINE=InnoDB"
-	migration.SkipPreRunChecks = true
+	migration.SkipChecks = append(migration.SkipChecks, "version")
 
 	err = migration.Run()
 	assert.NoError(t, err)
@@ -156,7 +156,7 @@ func TestE2ENullAlterWithReplicas(t *testing.T) {
 	migration.Alter = "ENGINE=InnoDB"
 	migration.ReplicaDSN = replicaDSN
 	migration.ReplicaMaxLag = 10 * time.Second
-	migration.SkipPreRunChecks = true
+	migration.SkipChecks = append(migration.SkipChecks, "version")
 
 	err = migration.Run()
 	assert.NoError(t, err)

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -364,6 +364,7 @@ func (r *Runner) runChecks(ctx context.Context, scope check.ScopeFlag) error {
 		TargetChunkTime: r.migration.TargetChunkTime,
 		Threads:         r.migration.Threads,
 		ReplicaMaxLag:   r.migration.ReplicaMaxLag,
+		SkipChecks:      r.migration.SkipChecks,
 		// For the pre-run checks we don't have a DB connection yet.
 		// Instead we check the credentials provided.
 		Host:     r.migration.Host,

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cashapp/spirit/pkg/check"
 	"github.com/cashapp/spirit/pkg/dbconn"
 	"github.com/cashapp/spirit/pkg/metrics"
 	"github.com/cashapp/spirit/pkg/testutils"
+	"github.com/cashapp/spirit/pkg/utils"
 
 	"github.com/cashapp/spirit/pkg/repl"
 	"github.com/cashapp/spirit/pkg/row"
@@ -2554,4 +2556,48 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
 	assert.True(t, m.usedResumeFromCheckpoint)
 	assert.NoError(t, m.Close())
+}
+
+func TestPreRunChecksE2E(t *testing.T) {
+	// We test the checks in tests for that package, but we also want to test
+	// that the checks run correctly when instantiating a migration.
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+
+	m, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  1,
+		Table:    "test_checks_e2e",
+		Alter:    "engine=innodb",
+	})
+	assert.NoError(t, err)
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	assert.NoError(t, err)
+	defer db.Close()
+	err = m.runChecks(context.TODO(), check.ScopePreRun)
+	if utils.IsMySQL8(db) {
+		assert.NoError(t, err)
+	} else {
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "MySQL 8.0 is required")
+		return // no sense in running the rest of these tests
+	}
+
+	m, err = NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  1,
+		Table:    "test_checks_e2e",
+		Alter:    "ALGORITHM=inplace",
+	})
+	assert.NoError(t, err)
+	err = m.runChecks(context.TODO(), check.ScopePreRun)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported clause")
 }


### PR DESCRIPTION
The way the "version" check is currently skipped is pretty brute-force and means that any other PreRun checks would be skipped (if there were any other ones... such as the one I propose in #255).

This PR adds a hidden --skip-checks option that can be used to skip individual checks. Maybe people have their reasons. 🤷