### PR TITLE
initial support for RBR minimal image

### DIFF
--- a/.github/workflows/mysql8_rbr_minimal.yml
+++ b/.github/workflows/mysql8_rbr_minimal.yml
@@ -1,0 +1,21 @@
+name: MySQL 8.0.33 (RBR minimal)
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy MySQL
+        run: scripts/dbdeployer_install_8_rbr_minimal.sh
+
+      - name: Test
+        run: MYSQL_DSN="msandbox:msandbox@tcp(127.0.0.1:8033)/test" go test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This scenario is kind of a worse case for gh-ost since it prioritizes replicatio
 Spirit works with the default configuration of MySQL 8.0, but checks that you have not changed the following settings:
   - `log-bin`
   - `binlog_format=ROW`
-  - `binlog_row_image=FULL` (see [issue #221](https://github.com/cashapp/spirit/issues/221))
+  - `binlog_row_image=FULL` or `MINIMAL`
   - `innodb_autoinc_lock_mode=2`
   - `log_slave_updates=1`
 

--- a/pkg/check/configuration.go
+++ b/pkg/check/configuration.go
@@ -40,10 +40,10 @@ func configurationCheck(ctx context.Context, r Resources, logger loggers.Advance
 		// This is the auto-inc lock. It won't show up in SHOW PROCESSLIST that they are serial.
 		logger.Warn("innodb_autoinc_lock_mode != 2. This will cause the migration to run slower than expected because concurrent inserts to the new table will be serialized.")
 	}
-	if binlogRowImage != "FULL" {
-		// This might not be required, but is the only option that has been tested so far.
+	if !(binlogRowImage == "FULL" || binlogRowImage == "MINIMAL") {
+		// This might not be required, but these are the only options that have been tested so far.
 		// To keep the testing scope reduced for now, it is required.
-		return errors.New("binlog_row_image must be FULL")
+		return errors.New("binlog_row_image must be FULL or MINIMAL")
 	}
 	if logBin != "1" {
 		// This is a hard requirement because we need to be able to read the binlog.

--- a/pkg/check/configuration_test.go
+++ b/pkg/check/configuration_test.go
@@ -23,13 +23,20 @@ func TestConfiguration(t *testing.T) {
 	err = configurationCheck(context.Background(), r, logrus.New())
 	assert.NoError(t, err) // all looks good of course.
 
+	// Current binlog row image format.
+	var binlogRowImage string
+	assert.NoError(t, db.QueryRow("SELECT @@global.binlog_row_image").Scan(&binlogRowImage))
+
 	// Binlog row image is dynamic, so we can change it.
-	_, err = db.Exec("SET GLOBAL binlog_row_image = 'MINIMAL'")
+	// We could probably support NOBLOB with some testing, but it's not
+	// used commonly so its useful for testing.
+	_, err = db.Exec("SET GLOBAL binlog_row_image = 'NOBLOB'")
 	assert.NoError(t, err)
 
 	err = configurationCheck(context.Background(), r, logrus.New())
 	assert.Error(t, err)
 
-	_, err = db.Exec("SET GLOBAL binlog_row_image = 'FULL'")
+	// restore the binlog row image format.
+	_, err = db.Exec("SET GLOBAL binlog_row_image = ?", binlogRowImage)
 	assert.NoError(t, err)
 }

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -129,13 +129,14 @@ func NewClientDefaultConfig() *ClientConfig {
 func (c *Client) OnRow(e *canal.RowsEvent) error {
 	var i = 0
 	for _, row := range e.Rows {
-		i++
-		if e.Action == canal.UpdateAction && i%2 == 0 {
-			// For UpdateAction there is always a before and after image (i.e. e.Rows is always in pairs.)
-			// The first row is the before image, the second is the after image.
-			// We only need to capture one of the events, and since in MINIMAL RBR row
-			// image the PK is only included in the before, we chose that one.
-			continue
+		// For UpdateAction there is always a before and after image (i.e. e.Rows is always in pairs.)
+		// We only need to capture one of the events, and since in MINIMAL RBR row
+		// image the PK is only included in the before, we chose that one.
+		if e.Action == canal.UpdateAction {
+			i++
+			if i%2 == 0 {
+				continue
+			}
 		}
 		key, err := c.table.PrimaryKeyValues(row)
 		if err != nil {

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -282,7 +282,7 @@ func TestReplClientQueue(t *testing.T) {
 	// optimization these deletes will be queued immediately.
 	testutils.RunSQL(t, "DELETE FROM replqueuet1 LIMIT 1000")
 	assert.NoError(t, client.BlockWait(context.TODO()))
-	assert.Equal(t, client.GetDeltaLen(), 1000)
+	assert.Equal(t, 1000, client.GetDeltaLen())
 
 	// Read from the copier
 	chk, err := copier.Next4Test()

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -293,7 +293,8 @@ func TestKeyColumnsValuesExtraction(t *testing.T) {
 	assert.NoError(t, err)
 
 	row := []interface{}{id, name, age}
-	pkVals := t1.PrimaryKeyValues(row)
+	pkVals, err := t1.PrimaryKeyValues(row)
 	assert.Equal(t, id, pkVals[0])
 	assert.Equal(t, age, pkVals[1])
+	assert.NoError(t, err)
 }

--- a/scripts/dbdeployer_install_8_rbr_minimal.sh
+++ b/scripts/dbdeployer_install_8_rbr_minimal.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -xe
+
+sudo apt install -y libncurses5
+
+go install github.com/datacharmer/dbdeployer@latest
+
+dbdeployer init
+dbdeployer deploy single 8.0.33
+
+echo "binlog_row_image=MINIMAL" >> ~/sandboxes/msb_8_0_33/my.sandbox.cnf
+
+~/sandboxes/msb_8_0_33/restart


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Fixes https://github.com/cashapp/spirit/issues/221

This required a change to the replication applier. Previously, on an update operation the before-image and after-image were inspected to extract the `PRIMARY KEY`. Now only the before image is used.