### PR TITLE
reduce checksum failures

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -3026,12 +3026,7 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	ops = append(ops, fmt.Sprintf("%s=%s", "innodb_lock_wait_timeout", url.QueryEscape(fmt.Sprint(config.InnodbLockWaitTimeout))))
 	ops = append(ops, fmt.Sprintf("%s=%s", "lock_wait_timeout", url.QueryEscape(fmt.Sprint(config.LockWaitTimeout))))
 	ops = append(ops, fmt.Sprintf("%s=%s", "range_optimizer_max_mem_size", url.QueryEscape(fmt.Sprint(config.RangeOptimizerMaxMemSize))))
-
-	if config.Aurora20Compatible {
-		ops = append(ops, fmt.Sprintf("%s=%s", "tx_isolation", url.QueryEscape(`"read-committed"`))) // Aurora 2.0
-	} else {
-		ops = append(ops, fmt.Sprintf("%s=%s", "transaction_isolation", url.QueryEscape(`"read-committed"`))) // MySQL 8.0
-	}
+	ops = append(ops, fmt.Sprintf("%s=%s", "transaction_isolation", url.QueryEscape(`"read-committed"`)))
 	// go driver options, should set:
 	// character_set_client, character_set_connection, character_set_results
 	ops = append(ops, fmt.Sprintf("%s=%s", "charset", "binary"))
@@ -3054,14 +3049,7 @@ func New(inputDSN string, config *DBConfig) (*sql.DB, error) {
 	}
 	if err := db.Ping(); err != nil {
 		utils.ErrInErr(db.Close())
-		if config.Aurora20Compatible {
-			return nil, err // Already tried it, didn't work.
-		}
-		// This could be because of transaction_isolation vs. tx_isolation.
-		// Try changing to Aurora 2.0 compatible mode and retrying.
-		// because config is a pointer, it will update future calls too.
-		config.Aurora20Compatible = true
-		return New(inputDSN, config)
+		return nil, err
 	}
 	db.SetMaxOpenConns(config.MaxOpenConnections)
 	db.SetConnMaxLifetime(maxConnLifetime)

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -28,7 +28,6 @@ type DBConfig struct {
 	InnodbLockWaitTimeout    int
 	MaxRetries               int
 	MaxOpenConnections       int
-	Aurora20Compatible       bool // use tx_isolation instead of transaction_isolation
 	RangeOptimizerMaxMemSize int64
 }
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -233,6 +233,7 @@ func (r *Runner) Run(originalCtx context.Context) error {
 		return err
 	}
 	r.logger.Info("copy rows complete")
+	r.replClient.SetKeyAboveWatermarkOptimization(false) // should no longer be used.
 
 	// r.waitOnSentinel may return an error if there is
 	// some unexpected problem checking for the existence of
@@ -495,6 +496,7 @@ func (r *Runner) setup(ctx context.Context) error {
 	// If this is NOT nil then it will use this optimization when determining
 	// if it can ignore a KEY.
 	r.replClient.KeyAboveCopierCallback = r.copier.KeyAboveHighWatermark
+	r.replClient.SetKeyAboveWatermarkOptimization(true)
 
 	// Start routines in table and replication packages to
 	// Continuously update the min/max and estimated rows
@@ -800,9 +802,6 @@ func (r *Runner) getCurrentState() migrationState {
 
 func (r *Runner) setCurrentState(s migrationState) {
 	atomic.StoreInt32((*int32)(&r.currentState), int32(s))
-	if s > stateCopyRows && r.replClient != nil {
-		r.replClient.SetKeyAboveWatermarkOptimization(false)
-	}
 }
 
 func (r *Runner) dumpCheckpoint(ctx context.Context) error {

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -1305,6 +1305,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	m.replClient.KeyAboveCopierCallback = m.copier.KeyAboveHighWatermark
 	err = m.replClient.Run()
 	assert.NoError(t, err)
+	m.replClient.SetKeyAboveWatermarkOptimization(true)
 
 	// Now we are ready to start copying rows.
 	// Instead of calling m.copyRows() we will step through it manually.

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -89,6 +89,7 @@ func TestReplClientComplex(t *testing.T) {
 	assert.NoError(t, err)
 	// Attach copier's keyabovewatermark to the repl client
 	client.KeyAboveCopierCallback = copier.KeyAboveHighWatermark
+	client.SetKeyAboveWatermarkOptimization(true)
 
 	assert.NoError(t, copier.Open4Test()) // need to manually open because we are not calling Run()
 

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -408,10 +408,13 @@ func (t *chunkerOptimistic) calculateNewTargetChunkSize() uint64 {
 	return uint64(newTargetRows)
 }
 
+// KeyAboveHighWatermark returns true if the key is above the high watermark.
+// TRUE means that the row will be discarded so if there is any ambiguity,
+// it's important to return FALSE.
 func (t *chunkerOptimistic) KeyAboveHighWatermark(key interface{}) bool {
 	t.Lock()
 	defer t.Unlock()
-	if t.chunkPtr.IsNil() {
+	if t.chunkPtr.IsNil() && t.checkpointHighPtr.IsNil() {
 		return true // every key is above because we haven't started copying.
 	}
 	if t.finalChunkSent {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

This is another attempt to fix https://github.com/cashapp/spirit/issues/248

There seems to be a case where the checksum is failing, and inspection of the rows show that it's not garbled data but a `last_viewed_at DATETIME(3)` column which an update was missed for.

All the cases affected appear to be resume cases (typically it's gone to resume because it has high lock wait timeouts while trying to get a lock). Which leads me to believe it's:

1. The flushing under lock mechanism. This PR changes it to be the same as used in 8.0 cutover
2. The key above watermark optimization is incorrectly ignoring rows. I've added protection to make sure there's no race on resume where it could return incorrectly 
3. The binlog checkpoint is ahead of itself. We're pretending work has safely been applied, but it hasn't.

Note: (2) is more likely since (1) occurs under both resume and non-resume cases. I don't think the cause is (3).

There is also a little bit more cleanup to remove 5.7 support.