### PR TITLE
Support dynamic repl applier

### DIFF
--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -3,6 +3,7 @@ package checksum
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cashapp/spirit/pkg/testutils"
 
@@ -36,9 +37,9 @@ func TestBasicChecksum(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 
@@ -71,9 +72,9 @@ func TestBasicValidation(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 
@@ -108,9 +109,9 @@ func TestFixCorrupt(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 
@@ -151,9 +152,9 @@ func TestCorruptChecksum(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 
@@ -183,9 +184,9 @@ func TestBoundaryCases(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 
@@ -247,9 +248,9 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t2, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
 

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/cashapp/spirit/pkg/dbconn"
 	"github.com/cashapp/spirit/pkg/repl"
@@ -44,9 +45,9 @@ func TestCutOver(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t1new, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	// the feed must be started.
 	assert.NoError(t, feed.Run())
@@ -103,9 +104,9 @@ func TestMDLLockFails(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t1new, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	// the feed must be started.
 	assert.NoError(t, feed.Run())
@@ -141,9 +142,9 @@ func TestInvalidOptions(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, t1, t1new, cfg.User, cfg.Passwd, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
 	})
 	_, err = NewCutOver(db, nil, t1new, feed, dbconn.NewDBConfig(), logger)
 	assert.Error(t, err)

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -457,9 +457,9 @@ func (r *Runner) setup(ctx context.Context) error {
 			return err
 		}
 		r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
-			Logger:      r.logger,
-			Concurrency: r.migration.Threads,
-			BatchSize:   repl.DefaultBatchSize,
+			Logger:          r.logger,
+			Concurrency:     r.migration.Threads,
+			TargetBatchTime: r.migration.TargetChunkTime,
 		})
 		// Start the binary log feed now
 		if err := r.replClient.Run(); err != nil {
@@ -496,7 +496,7 @@ func (r *Runner) setup(ctx context.Context) error {
 	// If this is NOT nil then it will use this optimization when determining
 	// if it can ignore a KEY.
 	r.replClient.KeyAboveCopierCallback = r.copier.KeyAboveHighWatermark
-	r.replClient.SetKeyAboveWatermarkOptimization(true)
+	//r.replClient.SetKeyAboveWatermarkOptimization(true)
 
 	// Start routines in table and replication packages to
 	// Continuously update the min/max and estimated rows
@@ -716,9 +716,9 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	// Set the binlog position.
 	// Create a binlog subscriber
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
-		Logger:      r.logger,
-		Concurrency: r.migration.Threads,
-		BatchSize:   repl.DefaultBatchSize,
+		Logger:          r.logger,
+		Concurrency:     r.migration.Threads,
+		TargetBatchTime: r.migration.TargetChunkTime,
 	})
 	r.replClient.SetPos(mysql.Position{
 		Name: binlogName,

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -496,7 +496,7 @@ func (r *Runner) setup(ctx context.Context) error {
 	// If this is NOT nil then it will use this optimization when determining
 	// if it can ignore a KEY.
 	r.replClient.KeyAboveCopierCallback = r.copier.KeyAboveHighWatermark
-	//r.replClient.SetKeyAboveWatermarkOptimization(true)
+	r.replClient.SetKeyAboveWatermarkOptimization(true)
 
 	// Start routines in table and replication packages to
 	// Continuously update the min/max and estimated rows

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -761,9 +761,9 @@ func TestCheckpoint(t *testing.T) {
 	assert.NoError(t, r.alterNewTable(context.TODO()))
 	assert.NoError(t, r.createCheckpointTable(context.TODO()))
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
-		Logger:      logrus.New(), // don't use the logger for migration since we feed status to it.
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logrus.New(), // don't use the logger for migration since we feed status to it.
+		Concurrency:     4,
+		TargetBatchTime: r.migration.TargetChunkTime,
 	})
 	r.copier, err = row.NewCopier(r.db, r.table, r.newTable, row.NewCopierDefaultConfig())
 	assert.NoError(t, err)
@@ -909,9 +909,9 @@ func TestCheckpointRestore(t *testing.T) {
 	assert.NoError(t, r.createCheckpointTable(context.TODO()))
 
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
-		Logger:      logrus.New(),
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logrus.New(),
+		Concurrency:     4,
+		TargetBatchTime: r.migration.TargetChunkTime,
 	})
 	r.copier, err = row.NewCopier(r.db, r.table, r.newTable, row.NewCopierDefaultConfig())
 	assert.NoError(t, err)
@@ -995,9 +995,9 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	assert.NoError(t, m.createCheckpointTable(context.TODO()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: m.migration.TargetChunkTime,
 	})
 	m.copier, err = row.NewCopier(m.db, m.table, m.newTable, row.NewCopierDefaultConfig())
 	assert.NoError(t, err)
@@ -1190,9 +1190,9 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	assert.NoError(t, m.createCheckpointTable(context.TODO()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: m.migration.TargetChunkTime,
 	})
 	m.copier, err = row.NewCopier(m.db, m.table, m.newTable, &row.CopierConfig{
 		Concurrency:     m.migration.Threads,
@@ -1314,9 +1314,9 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	assert.NoError(t, m.createCheckpointTable(context.TODO()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   10000,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: m.migration.TargetChunkTime,
 	})
 	m.copier, err = row.NewCopier(m.db, m.table, m.newTable, &row.CopierConfig{
 		Concurrency:     m.migration.Threads,
@@ -1915,9 +1915,9 @@ func TestE2ERogueValues(t *testing.T) {
 	assert.NoError(t, m.createCheckpointTable(context.TODO()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   repl.DefaultBatchSize,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: m.migration.TargetChunkTime,
 	})
 	m.copier, err = row.NewCopier(m.db, m.table, m.newTable, &row.CopierConfig{
 		Concurrency:     m.migration.Threads,
@@ -2077,9 +2077,9 @@ func TestResumeFromCheckpointPhantom(t *testing.T) {
 	assert.NoError(t, m.createCheckpointTable(ctx))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
-		Logger:      logger,
-		Concurrency: 4,
-		BatchSize:   repl.DefaultBatchSize,
+		Logger:          logger,
+		Concurrency:     4,
+		TargetBatchTime: m.migration.TargetChunkTime,
 	})
 	m.copier, err = row.NewCopier(m.db, m.table, m.newTable, &row.CopierConfig{
 		Concurrency:     m.migration.Threads,

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -31,7 +31,12 @@ const (
 	// Since on some of our Aurora tables with out-of-cache workloads only copy ~300 rows per second,
 	// we probably shouldn't set this any larger than about 1K. It will also use
 	// multiple-flush-threads, which should help it group commit and still be fast.
+	// This is only used as an initial starting value. It will auto-scale based on the DefaultTargetBatchTime.
 	DefaultBatchSize = 1000
+
+	// DefaultBatchTime is the target time for flushing REPLACE/DELETE statements.
+	DefaultTargetBatchTime = time.Millisecond * 500
+
 	// DefaultFlushInterval is the time that the client will flush all binlog changes to disk.
 	// Longer values require more memory, but permit more merging.
 	// I expect we will change this to 1hr-24hr in the future.
@@ -42,6 +47,22 @@ type queuedChange struct {
 	key      string
 	isDelete bool
 }
+
+type statement struct {
+	keys int
+	stmt string
+}
+
+func extractStmt(stmts []statement) []string {
+	var trimmed []string
+	for _, stmt := range stmts {
+		if stmt.stmt != "" {
+			trimmed = append(trimmed, stmt.stmt)
+		}
+	}
+	return trimmed
+}
+
 type Client struct {
 	canal.DummyEventHandler
 	sync.Mutex
@@ -76,8 +97,11 @@ type Client struct {
 
 	isClosed bool
 
-	batchSize   int64
-	concurrency int
+	statisticsLock  sync.Mutex
+	targetBatchTime time.Duration
+	targetBatchSize int64 // will auto-adjust over time, use atomic to read/set
+	timingHistory   []time.Duration
+	concurrency     int
 
 	// The periodic flush lock is just used for ensuring only one periodic flush runs at a time,
 	// and when we disable it, no more periodic flushes will run. The actual flushing is protected
@@ -98,23 +122,24 @@ func NewClient(db *sql.DB, host string, table, newTable *table.TableInfo, userna
 		password:        password,
 		binlogChangeset: make(map[string]bool),
 		logger:          config.Logger,
-		batchSize:       config.BatchSize,
+		targetBatchTime: config.TargetBatchTime,
+		targetBatchSize: DefaultBatchSize, // initial starting value.
 		concurrency:     config.Concurrency,
 	}
 }
 
 type ClientConfig struct {
-	BatchSize   int64
-	Concurrency int
-	Logger      loggers.Advanced
+	TargetBatchTime time.Duration
+	Concurrency     int
+	Logger          loggers.Advanced
 }
 
 // NewClientDefaultConfig returns a default config for the copier.
 func NewClientDefaultConfig() *ClientConfig {
 	return &ClientConfig{
-		Concurrency: 4,
-		BatchSize:   DefaultBatchSize,
-		Logger:      logrus.New(),
+		Concurrency:     4,
+		TargetBatchTime: DefaultTargetBatchTime,
+		Logger:          logrus.New(),
 	}
 }
 
@@ -405,13 +430,14 @@ func (c *Client) flushQueue(ctx context.Context, underLock bool, lock *dbconn.Ta
 	}
 
 	// Otherwise, flush the changes.
-	var stmts []string
+	var stmts []statement
 	var buffer []string
 	prevKey := changesToFlush[0] // for initialization
+	target := int(atomic.LoadInt64(&c.targetBatchSize))
 	for _, change := range changesToFlush {
 		// We are changing from DELETE to REPLACE
 		// or vice versa, *or* the buffer is getting very large.
-		if change.isDelete != prevKey.isDelete || len(buffer) > DefaultBatchSize {
+		if change.isDelete != prevKey.isDelete || len(buffer) > target {
 			if prevKey.isDelete {
 				stmts = append(stmts, c.createDeleteStmt(buffer))
 			} else {
@@ -432,13 +458,13 @@ func (c *Client) flushQueue(ctx context.Context, underLock bool, lock *dbconn.Ta
 		// Execute under lock means it is a final flush
 		// We need to use the lock connection to do this
 		// so there is no parallelism.
-		if err := lock.ExecUnderLock(ctx, stmts); err != nil {
+		if err := lock.ExecUnderLock(ctx, extractStmt(stmts)); err != nil {
 			return err
 		}
 	} else {
 		// Execute the statements in a transaction.
 		// They still need to be single threaded.
-		if _, err := dbconn.RetryableTransaction(ctx, c.db, true, dbconn.NewDBConfig(), stmts...); err != nil {
+		if _, err := dbconn.RetryableTransaction(ctx, c.db, true, dbconn.NewDBConfig(), extractStmt(stmts)...); err != nil {
 			return err
 		}
 	}
@@ -468,8 +494,9 @@ func (c *Client) flushMap(ctx context.Context, underLock bool, lock *dbconn.Tabl
 	// We must now apply the changeset setToFlush to the new table.
 	var deleteKeys []string
 	var replaceKeys []string
-	var stmts []string
+	var stmts []statement
 	var i int64
+	target := atomic.LoadInt64(&c.targetBatchSize)
 	for key, isDelete := range setToFlush {
 		i++
 		if isDelete {
@@ -477,12 +504,12 @@ func (c *Client) flushMap(ctx context.Context, underLock bool, lock *dbconn.Tabl
 		} else {
 			replaceKeys = append(replaceKeys, key)
 		}
-		if (i % c.batchSize) == 0 {
+		if (i % target) == 0 {
 			stmts = append(stmts, c.createDeleteStmt(deleteKeys))
 			stmts = append(stmts, c.createReplaceStmt(replaceKeys))
 			deleteKeys = []string{}
 			replaceKeys = []string{}
-			atomic.AddInt64(&c.binlogChangesetDelta, -c.batchSize)
+			atomic.AddInt64(&c.binlogChangesetDelta, -target)
 		}
 	}
 	stmts = append(stmts, c.createDeleteStmt(deleteKeys))
@@ -492,7 +519,7 @@ func (c *Client) flushMap(ctx context.Context, underLock bool, lock *dbconn.Tabl
 		// Execute under lock means it is a final flush
 		// We need to use the lock connection to do this
 		// so there is no parallelism.
-		if err := lock.ExecUnderLock(ctx, stmts); err != nil {
+		if err := lock.ExecUnderLock(ctx, extractStmt(stmts)); err != nil {
 			return err
 		}
 	} else {
@@ -505,7 +532,9 @@ func (c *Client) flushMap(ctx context.Context, underLock bool, lock *dbconn.Tabl
 		for _, stmt := range stmts {
 			s := stmt
 			g.Go(func() error {
-				_, err := dbconn.RetryableTransaction(errGrpCtx, c.db, false, dbconn.NewDBConfig(), s)
+				startTime := time.Now()
+				_, err := dbconn.RetryableTransaction(errGrpCtx, c.db, false, dbconn.NewDBConfig(), s.stmt)
+				c.feedback(s.keys, time.Since(startTime))
 				return err
 			})
 		}
@@ -520,7 +549,7 @@ func (c *Client) flushMap(ctx context.Context, underLock bool, lock *dbconn.Tabl
 	return nil
 }
 
-func (c *Client) createDeleteStmt(deleteKeys []string) string {
+func (c *Client) createDeleteStmt(deleteKeys []string) statement {
 	var deleteStmt string
 	if len(deleteKeys) > 0 {
 		deleteStmt = fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (%s)",
@@ -529,10 +558,13 @@ func (c *Client) createDeleteStmt(deleteKeys []string) string {
 			c.pksToRowValueConstructor(deleteKeys),
 		)
 	}
-	return deleteStmt
+	return statement{
+		keys: len(deleteKeys),
+		stmt: deleteStmt,
+	}
 }
 
-func (c *Client) createReplaceStmt(replaceKeys []string) string {
+func (c *Client) createReplaceStmt(replaceKeys []string) statement {
 	var replaceStmt string
 	if len(replaceKeys) > 0 {
 		replaceStmt = fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE (%s) IN (%s)",
@@ -544,7 +576,46 @@ func (c *Client) createReplaceStmt(replaceKeys []string) string {
 			c.pksToRowValueConstructor(replaceKeys),
 		)
 	}
-	return replaceStmt
+	return statement{
+		keys: len(replaceKeys),
+		stmt: replaceStmt,
+	}
+}
+
+// feedback provides feedback on the apply time of changesets.
+// We use this to refine the targetBatchSize. This is a little bit
+// different for feedback for the copier, because frequently the batches
+// will not be full. We still need to use a p90-like mechanism though,
+// because the rows being changed are by definition more likely to be hotspots.
+// Hotspots == Lock Contention. This is one of the exact reasons why we are
+// chunking in the first place. The probability that the applier can cause
+// impact on OLTP workloads is much higher than the copier.
+func (c *Client) feedback(numberOfKeys int, d time.Duration) {
+	c.statisticsLock.Lock()
+	defer c.statisticsLock.Unlock()
+	if numberOfKeys == 0 {
+		// If the number of keys is zero, we can't
+		// calculate anything so we just return
+		return
+	}
+	// For the p90-like mechanism rather than storing all the previous
+	// durations, because the numberOfKeys is variable we instead store
+	// the timePerKey. We then adjust the targetBatchSize based on this.
+	// This creates some skew because small batches will have a higher
+	// timePerKey, which can create a back log. Which results in a smaller
+	// timePerKey. So at least the skew *should* be self-correcting. This
+	// has not yet been proven though.
+	timePerKey := d / time.Duration(numberOfKeys)
+	c.timingHistory = append(c.timingHistory, timePerKey)
+
+	// If we have enough feedback re-evaluate the target batch size
+	// based on the p90 timePerKey.
+	if len(c.timingHistory) >= 10 {
+		timePerKey := table.LazyFindP90(c.timingHistory)
+		newBatchSize := int64(float64(c.targetBatchTime) / float64(timePerKey))
+		atomic.StoreInt64(&c.targetBatchSize, newBatchSize)
+		c.timingHistory = nil // reset
+	}
 }
 
 // Flush empties the changeset in a loop until the amount of changes is considered "trivial".
@@ -610,7 +681,10 @@ func (c *Client) StartPeriodicFlush(ctx context.Context, interval time.Duration)
 				c.logger.Errorf("error flushing binary log: %v", err)
 			}
 			c.periodicFlushLock.Unlock()
-			c.logger.Infof("finished periodic flush of binary log: duration=%v", time.Since(startLoop))
+			c.logger.Infof("finished periodic flush of binary log: total-duration=%v batch-size=%d",
+				time.Since(startLoop),
+				atomic.LoadInt64(&c.targetBatchSize),
+			)
 		}
 	}
 }

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -386,7 +386,7 @@ func (t *chunkerComposite) boundaryCheckTargetChunkSize(newTarget uint64) uint64
 
 func (t *chunkerComposite) calculateNewTargetChunkSize() uint64 {
 	// We do all our math as float64 of time in ns
-	p90 := float64(lazyFindP90(t.chunkTimingInfo))
+	p90 := float64(LazyFindP90(t.chunkTimingInfo))
 	targetTime := float64(t.ChunkerTarget)
 	newTargetRows := float64(t.chunkSize) * (targetTime / p90)
 	return uint64(newTargetRows)

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -390,7 +390,7 @@ func (t *chunkerOptimistic) boundaryCheckTargetChunkSize(newTarget uint64) uint6
 
 func (t *chunkerOptimistic) calculateNewTargetChunkSize() uint64 {
 	// We do all our math as float64 of time in ns
-	p90 := float64(lazyFindP90(t.chunkTimingInfo))
+	p90 := float64(LazyFindP90(t.chunkTimingInfo))
 	targetTime := float64(t.ChunkerTarget)
 	newTargetRows := float64(t.chunkSize) * (targetTime / p90)
 	// switch to prefetch chunking if:

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -8,10 +8,10 @@ import (
 	"time"
 )
 
-// lazyFindP90 finds the second to last value in a slice.
+// LazyFindP90 finds the second to last value in a slice.
 // This is the same as a p90 if there are 10 values, but if
 // there were 100 values it would technically be a p99 etc.
-func lazyFindP90(a []time.Duration) time.Duration {
+func LazyFindP90(a []time.Duration) time.Duration {
 	sort.Slice(a, func(i, j int) bool {
 		return a[i] > a[j]
 	})

--- a/pkg/table/utils_test.go
+++ b/pkg/table/utils_test.go
@@ -20,7 +20,7 @@ func TestFindP90(t *testing.T) {
 		1 * time.Second,
 		1 * time.Second,
 	}
-	assert.Equal(t, 3*time.Second, lazyFindP90(times))
+	assert.Equal(t, 3*time.Second, LazyFindP90(times))
 }
 
 type castableTpTest struct {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Fixes https://github.com/cashapp/spirit/issues/281

I disabled key above watermark to test it:

```
go run main.go --database finch --table customers --target-chunk-time=100ms
INFO[0000] Starting spirit migration: concurrency=4 target-chunk-size=100ms table=finch.customers alter="engine=innodb"
INFO[0000] unable to use INPLACE: ALTER either does not support INPLACE or when performed as INPLACE could take considerable time. Use --force-inplace to override this safety check
INFO[0000] create BinlogSyncer with config {ServerID:1643 Flavor:mysql Host:127.0.0.1 Port:3306 User:msandbox Password: Localhost: Charset:utf8 SemiSyncEnabled:false RawModeEnabled:false TLSConfig:<nil> ParseTime:false TimestampStringLocation:UTC UseDecimal:false RecvBufferSize:0 HeartbeatPeriod:0s ReadTimeout:0s MaxReconnectAttempts:0 DisableRetrySync:false VerifyChecksum:false DumpCommandFlag:0 Option:<nil> Logger:0x14000312990 Dialer:0x1025ca960 RowsEventDecodeFunc:0x1027d7010 TableMapOptionalMetaDecodeFunc:<nil> DiscardGTIDSet:false EventCacheCount:10240}
WARN[0000] resuming from checkpoint. low-watermark: {"Key":["id"],"ChunkSize":21568,"LowerBound":{"Value": ["56844555"],"Inclusive":true},"UpperBound":{"Value": ["56866123"],"Inclusive":false}} log-file: binlog.000221 log-pos: 31151408 copy-rows: 56866069
INFO[0000] skip dump, use last binlog replication pos (binlog.000221, 31151408) or GTID set <nil>
INFO[0000] begin to sync binlog from position (binlog.000221, 31151408)
INFO[0000] start sync binlog at binlog file (binlog.000221, 31151408)
INFO[0030] migration status: state=copyRows copy-progress=66589446/80656478 82.56% binlog-deltas=173886 total-time=30s copier-time=30s copier-remaining-time=TBD copier-is-throttled=false conns-in-use=4
INFO[0033] finished periodic flush of binary log: total-duration=3.600518417s batch-size=684
INFO[0050] checkpoint: low-watermark={"Key":["id"],"ChunkSize":2994,"LowerBound":{"Value": ["70114443"],"Inclusive":true},"UpperBound":{"Value": ["70117437"],"Inclusive":false}} log-file=binlog.000223 log-pos=278165976 rows-copied=66823574 rows-copied-logical=70140004
INFO[0060] migration status: state=copyRows copy-progress=71713054/80656478 88.91% binlog-deltas=163991 total-time=1m0s copier-time=1m0s copier-remaining-time=56s copier-is-throttled=false conns-in-use=4
INFO[0063] finished periodic flush of binary log: total-duration=3.443187041s batch-size=2209
INFO[0090] migration status: state=copyRows copy-progress=76778090/80656478 95.19% binlog-deltas=162733 total-time=1m30s copier-time=1m30s copier-remaining-time=19s copier-is-throttled=false conns-in-use=4
INFO[0092] finished periodic flush of binary log: total-duration=2.290715542s batch-size=2739
INFO[0100] checkpoint: low-watermark={"Key":["id"],"ChunkSize":2362,"LowerBound":{"Value": ["78527913"],"Inclusive":true},"UpperBound":{"Value": ["78530275"],"Inclusive":false}} log-file=binlog.000225 log-pos=337667856 rows-copied=75236396 rows-copied-logical=78552842
INFO[0106] approaching the end of the table, synchronously updating statistics
INFO[0106] copy rows complete
INFO[0106] starting to flush changeset
INFO[0109] blocking until we have read all binary logs: current-pos=(binlog.000225, 1029254347) target-pos=(binlog.000225, 1029202410)
INFO[0110] blocking until we have read all binary logs: current-pos=(binlog.000225, 1034846849) target-pos=(binlog.000225, 1034831416)
INFO[0110] Running ANALYZE TABLE
INFO[0110] starting to flush changeset
INFO[0110] blocking until we have read all binary logs: current-pos=(binlog.000225, 1035296997) target-pos=(binlog.000225, 1035248102)
INFO[0110] starting checksum operation, this will require a table lock
WARN[0110] trying to acquire table lock, timeout: 30
WARN[0110] table lock acquired
WARN[0110] table lock released
INFO[0110] table unlocked, starting checksum
INFO[0120] migration status: state=checksum checksum-progress=10028571/81163794 binlog-deltas=66304 total-time=2m0s checksum-time=10s conns-in-use=4
INFO[0120] finished periodic flush of binary log: total-duration=586.939083ms batch-size=3584
INFO[0141] finished periodic flush of binary log: total-duration=1.059294292s batch-size=3116
INFO[0150] checkpoint: low-watermark={"Key":["id"],"ChunkSize":32965,"LowerBound":{"Value": ["81135109"],"Inclusive":true},"UpperBound":{"Value": ["81168074"],"Inclusive":false}} log-file=binlog.000226 log-pos=78060617 rows-copied=76354568 rows-copied-logical=81223606
INFO[0150] migration status: state=checksum checksum-progress=43509467/81163794 binlog-deltas=79482 total-time=2m30s checksum-time=40s conns-in-use=4
INFO[0150] finished periodic flush of binary log: total-duration=685.09925ms batch-size=3457
INFO[0171] finished periodic flush of binary log: total-duration=1.299912542s batch-size=3171
INFO[0180] migration status: state=checksum checksum-progress=80563765/81163794 binlog-deltas=70261 total-time=3m0s checksum-time=1m10s conns-in-use=4
INFO[0180] approaching the end of the table, synchronously updating statistics
INFO[0180] finished periodic flush of binary log: total-duration=663.692625ms batch-size=3089
INFO[0180] checksum passed
INFO[0180] starting to flush changeset
INFO[0180] blocking until we have read all binary logs: current-pos=(binlog.000226, 324443372) target-pos=(binlog.000226, 324406138)
INFO[0180] starting to flush changeset
INFO[0180] blocking until we have read all binary logs: current-pos=(binlog.000226, 324558825) target-pos=(binlog.000226, 324548969)
WARN[0180] Attempting final cut over operation (attempt 1/5)
WARN[0180] trying to acquire table lock, timeout: 30
WARN[0180] table lock acquired
WARN[0180] table lock released
WARN[0180] final cut over operation complete
INFO[0189] successfully dropped old table
INFO[0189] apply complete: instant-ddl=false inplace-ddl=false total-chunks=5172 copy-rows-time=1m47s checksum-time=1m11s total-time=3m9s conns-in-use=0
INFO[0189] closing canal
INFO[0189] syncer is closing...
INFO[0189] kill last connection id 512
INFO[0189] syncer is closed
```

If the target-chunk-time is changed to 2s:
```
go run main.go --database finch --table customers --target-chunk-time=2s
INFO[0000] Starting spirit migration: concurrency=4 target-chunk-size=2s table=finch.customers alter="engine=innodb"
INFO[0000] unable to use INPLACE: ALTER either does not support INPLACE or when performed as INPLACE could take considerable time. Use --force-inplace to override this safety check
INFO[0000] could not resume from checkpoint: reason=could not read from table '_customers_new'
INFO[0000] create BinlogSyncer with config {ServerID:1057 Flavor:mysql Host:127.0.0.1 Port:3306 User:msandbox Password: Localhost: Charset:utf8 SemiSyncEnabled:false RawModeEnabled:false TLSConfig:<nil> ParseTime:false TimestampStringLocation:UTC UseDecimal:false RecvBufferSize:0 HeartbeatPeriod:0s ReadTimeout:0s MaxReconnectAttempts:0 DisableRetrySync:false VerifyChecksum:false DumpCommandFlag:0 Option:<nil> Logger:0x14000316720 Dialer:0x100972960 RowsEventDecodeFunc:0x100b7f010 TableMapOptionalMetaDecodeFunc:<nil> DiscardGTIDSet:false EventCacheCount:10240}
INFO[0000] skip dump, use last binlog replication pos (binlog.000227, 225862138) or GTID set <nil>
INFO[0000] begin to sync binlog from position (binlog.000227, 225862138)
INFO[0000] start sync binlog at binlog file (binlog.000227, 225862138)
INFO[0030] migration status: state=copyRows copy-progress=7304258/83636461 8.73% binlog-deltas=132706 total-time=30s copier-time=30s copier-remaining-time=TBD copier-is-throttled=false conns-in-use=4
INFO[0033] finished periodic flush of binary log: total-duration=3.88942775s batch-size=16986
INFO[0050] checkpoint: low-watermark={"Key":["id"],"ChunkSize":100000,"LowerBound":{"Value": ["11852255"],"Inclusive":true},"UpperBound":{"Value": ["11952255"],"Inclusive":false}} log-file=binlog.000228 log-pos=627919167 rows-copied=11952242 rows-copied-logical=11953254
INFO[0060] migration status: state=copyRows copy-progress=14253254/83636461 17.04% binlog-deltas=137417 total-time=1m0s copier-time=1m0s copier-remaining-time=5m1s copier-is-throttled=false conns-in-use=4
INFO[0062] finished periodic flush of binary log: total-duration=2.647773334s batch-size=18560
INFO[0090] migration status: state=copyRows copy-progress=21304292/83636461 25.47% binlog-deltas=131884 total-time=1m30s copier-time=1m30s copier-remaining-time=3m59s copier-is-throttled=false conns-in-use=4
INFO[0092] finished periodic flush of binary log: total-duration=2.568579167s batch-size=44482
INFO[0100] checkpoint: low-watermark={"Key":["id"],"ChunkSize":93516,"LowerBound":{"Value": ["23519001"],"Inclusive":true},"UpperBound":{"Value": ["23612517"],"Inclusive":false}} log-file=binlog.000231 log-pos=284660106 rows-copied=23612504 rows-copied-logical=23613516
INFO[0120] migration status: state=copyRows copy-progress=28513516/83636461 34.09% binlog-deltas=140048 total-time=2m0s copier-time=2m0s copier-remaining-time=3m49s copier-is-throttled=false conns-in-use=4
INFO[0122] finished periodic flush of binary log: total-duration=2.666008459s batch-size=44482
INFO[0150] checkpoint: low-watermark={"Key":["id"],"ChunkSize":96778,"LowerBound":{"Value": ["35619111"],"Inclusive":true},"UpperBound":{"Value": ["35715889"],"Inclusive":false}} log-file=binlog.000232 log-pos=693201522 rows-copied=35715876 rows-copied-logical=35716888
INFO[0150] migration status: state=copyRows copy-progress=35716888/83636461 42.70% binlog-deltas=143859 total-time=2m30s copier-time=2m30s copier-remaining-time=3m15s copier-is-throttled=false conns-in-use=4
INFO[0153] finished periodic flush of binary log: total-duration=3.055304291s batch-size=44482
INFO[0180] migration status: state=copyRows copy-progress=43101162/83636461 51.53% binlog-deltas=144307 total-time=3m0s copier-time=3m0s copier-remaining-time=2m42s copier-is-throttled=false conns-in-use=4
INFO[0182] finished periodic flush of binary log: total-duration=2.120207417s batch-size=35792
INFO[0200] checkpoint: low-watermark={"Key":["id"],"ChunkSize":100000,"LowerBound":{"Value": ["47700163"],"Inclusive":true},"UpperBound":{"Value": ["47800163"],"Inclusive":false}} log-file=binlog.000235 log-pos=468460007 rows-copied=47800123 rows-copied-logical=47801162
INFO[0210] migration status: state=copyRows copy-progress=50301162/83636461 60.14% binlog-deltas=145562 total-time=3m30s copier-time=3m30s copier-remaining-time=2m13s copier-is-throttled=false conns-in-use=4
INFO[0212] finished periodic flush of binary log: total-duration=2.474144s batch-size=35792
INFO[0240] migration status: state=copyRows copy-progress=57293344/83636461 68.50% binlog-deltas=139396 total-time=4m0s copier-time=4m0s copier-remaining-time=1m49s copier-is-throttled=false conns-in-use=4
INFO[0242] finished periodic flush of binary log: total-duration=2.389713709s batch-size=52375
INFO[0250] checkpoint: low-watermark={"Key":["id"],"ChunkSize":92458,"LowerBound":{"Value": ["59616925"],"Inclusive":true},"UpperBound":{"Value": ["59709383"],"Inclusive":false}} log-file=binlog.000238 log-pos=164185710 rows-copied=59709329 rows-copied-logical=59710382

```

So you can see from this log line the batch size is changing:
```
INFO[0150] finished periodic flush of binary log: total-duration=685.09925ms batch-size=3457 -- first example
INFO[0033] finished periodic flush of binary log: total-duration=3.88942775s batch-size=16986 -- second
```

It currently only dynamically the cases where we are parallel writing the changes (i.e. not during the cutover flush under lock, and not when we have to use the queue instead of the map). These other cases could be fixed in future, but it would require more code reorganization.