### PR TITLE
Jayj/old table timestamped

### DIFF
--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -26,13 +26,14 @@ const (
 )
 
 type Resources struct {
-	DB              *sql.DB
-	Replica         *sql.DB
-	Table           *table.TableInfo
-	Alter           string
-	TargetChunkTime time.Duration
-	Threads         int
-	ReplicaMaxLag   time.Duration
+	DB                   *sql.DB
+	Replica              *sql.DB
+	Table                *table.TableInfo
+	Alter                string
+	TargetChunkTime      time.Duration
+	Threads              int
+	ReplicaMaxLag        time.Duration
+	SkipDropAfterCutover bool
 	// The following resources are only used by the
 	// pre-run checks
 	Host     string

--- a/pkg/check/tablename.go
+++ b/pkg/check/tablename.go
@@ -1,0 +1,62 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/siddontang/loggers"
+)
+
+const (
+	// Max table name length in MySQL
+	maxTableNameLength = 64
+
+	// Formats for table names
+	NameFormatSentinel     = "_%s_sentinel"
+	NameFormatCheckpoint   = "_%s_chkpnt"
+	NameFormatNew          = "_%s_new"
+	NameFormatOld          = "_%s_old"
+	NameFormatOldTimeStamp = "_%s_old_%s"
+	NameFormatTimestamp    = "20060102_150405"
+)
+
+var (
+	// The number of extra characters needed for table names with all possible
+	// formats. These vars are calculated in the `init` function below.
+	NameFormatNormalExtraChars    = 0
+	NameFormatTimestampExtraChars = 0
+)
+
+func init() {
+	registerCheck("tablename", tableNameCheck, ScopePreflight)
+
+	// Calculate the number of extra characters needed table names with all possible formats
+	for _, format := range []string{NameFormatSentinel, NameFormatCheckpoint, NameFormatNew, NameFormatOld} {
+		extraChars := len(strings.Replace(format, "%s", "", -1))
+		if extraChars > NameFormatNormalExtraChars {
+			NameFormatNormalExtraChars = extraChars
+		}
+	}
+
+	// Calculate the number of extra characters needed for table names with the old timestamp format
+	NameFormatTimestampExtraChars = len(strings.Replace(NameFormatOldTimeStamp, "%s", "", -1)) + len(NameFormatTimestamp)
+}
+
+func tableNameCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {
+	tableName := r.Table.TableName
+	if len(tableName) < 1 {
+		return fmt.Errorf("table name must be at least 1 character")
+	}
+
+	timestampTableNameLength := maxTableNameLength - NameFormatTimestampExtraChars
+	if r.SkipDropAfterCutover && len(tableName) > timestampTableNameLength {
+		return fmt.Errorf("table name must be less than %d characters when --skip-drop-after-cutover is set", timestampTableNameLength)
+	}
+
+	normalTableNameLength := maxTableNameLength - NameFormatNormalExtraChars
+	if len(tableName) > normalTableNameLength {
+		return fmt.Errorf("table name must be less than %d characters", normalTableNameLength)
+	}
+	return nil
+}

--- a/pkg/check/tablename.go
+++ b/pkg/check/tablename.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -46,7 +47,7 @@ func init() {
 func tableNameCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {
 	tableName := r.Table.TableName
 	if len(tableName) < 1 {
-		return fmt.Errorf("table name must be at least 1 character")
+		return errors.New("table name must be at least 1 character")
 	}
 
 	timestampTableNameLength := maxTableNameLength - NameFormatTimestampExtraChars

--- a/pkg/check/tablename_test.go
+++ b/pkg/check/tablename_test.go
@@ -1,0 +1,43 @@
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cashapp/spirit/pkg/table"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckTableNameConstants(t *testing.T) {
+	// Calculated extra chars should always be greater than 0
+	assert.Greater(t, NameFormatNormalExtraChars, 0)
+	assert.Greater(t, NameFormatTimestampExtraChars, 0)
+
+	// Calculated extra chars should be less than the max table name length
+	assert.Less(t, NameFormatNormalExtraChars, maxTableNameLength)
+	assert.Less(t, NameFormatTimestampExtraChars, maxTableNameLength)
+}
+
+func TestCheckTableName(t *testing.T) {
+	testTableName := func(name string, skipDropAfterCutover bool) error {
+		r := Resources{
+			Table: &table.TableInfo{
+				TableName: name,
+			},
+			SkipDropAfterCutover: skipDropAfterCutover,
+		}
+		return tableNameCheck(context.Background(), r, logrus.New())
+	}
+
+	assert.NoError(t, testTableName("a", false))
+	assert.NoError(t, testTableName("a", true))
+
+	assert.ErrorContains(t, testTableName("", false), "table name must be at least 1 character")
+	assert.ErrorContains(t, testTableName("", true), "table name must be at least 1 character")
+
+	longName := "thisisareallylongtablenamethisisareallylongtablenamethisisareallylongtablename"
+	assert.ErrorContains(t, testTableName(longName, false), "table name must be less than")
+	assert.ErrorContains(t, testTableName(longName, true), "table name must be less than")
+
+}

--- a/pkg/check/tablename_test.go
+++ b/pkg/check/tablename_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestCheckTableNameConstants(t *testing.T) {
 	// Calculated extra chars should always be greater than 0
-	assert.Greater(t, NameFormatNormalExtraChars, 0)
-	assert.Greater(t, NameFormatTimestampExtraChars, 0)
+	assert.Positive(t, NameFormatNormalExtraChars)
+	assert.Positive(t, NameFormatTimestampExtraChars)
 
 	// Calculated extra chars should be less than the max table name length
 	assert.Less(t, NameFormatNormalExtraChars, maxTableNameLength)
@@ -39,5 +39,4 @@ func TestCheckTableName(t *testing.T) {
 	longName := "thisisareallylongtablenamethisisareallylongtablenamethisisareallylongtablename"
 	assert.ErrorContains(t, testTableName(longName, false), "table name must be less than")
 	assert.ErrorContains(t, testTableName(longName, true), "table name must be less than")
-
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -597,7 +597,7 @@ func (r *Runner) dropOldTable(ctx context.Context) error {
 }
 
 func (r *Runner) oldTableName() string {
-	return fmt.Sprintf("_%s_old_%s", r.table.TableName, r.startTime.UTC().Format("20060102_150405Z"))
+	return fmt.Sprintf("_%s_old_%s", r.table.TableName, r.startTime.UTC().Format("20060102_150405.000"))
 }
 
 func (r *Runner) attemptInstantDDL(ctx context.Context) error {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -278,7 +278,7 @@ func (r *Runner) Run(originalCtx context.Context) error {
 	// It's time for the final cut-over, where
 	// the tables are swapped under a lock.
 	r.setCurrentState(stateCutOver)
-	cutover, err := NewCutOver(r.db, r.table, r.newTable, r.replClient, r.dbConfig, r.logger)
+	cutover, err := NewCutOver(r.db, r.table, r.newTable, r.oldTableName(), r.replClient, r.dbConfig, r.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -294,10 +294,12 @@ func (r *Runner) Run(originalCtx context.Context) error {
 		if err := r.dropOldTable(ctx); err != nil {
 			// Don't return the error because our automation
 			// will retry the migration (but it's already happened)
-			r.logger.Errorf("migration successful but failed to drop old table: %v", err)
+			r.logger.Errorf("migration successful but failed to drop old table: %s - %v", r.oldTableName(), err)
 		} else {
-			r.logger.Info("successfully dropped old table")
+			r.logger.Info("successfully dropped old table: ", r.oldTableName())
 		}
+	} else {
+		r.logger.Info("skipped dropping old table: ", r.oldTableName())
 	}
 	checksumTime := time.Duration(0)
 	if r.checker != nil {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -591,8 +591,11 @@ func (r *Runner) alterNewTable(ctx context.Context) error {
 }
 
 func (r *Runner) dropOldTable(ctx context.Context) error {
-	oldName := fmt.Sprintf("_%s_old", r.table.TableName)
-	return dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, oldName)
+	return dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, r.oldTableName())
+}
+
+func (r *Runner) oldTableName() string {
+	return fmt.Sprintf("_%s_old_%s", r.table.TableName, r.startTime.UTC().Format("20060102_150405Z"))
 }
 
 func (r *Runner) attemptInstantDDL(ctx context.Context) error {

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -2624,7 +2624,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	sentinelWaitLimit = 10 * time.Second
 	statusInterval = 500 * time.Millisecond
 
-	tableName := `resume_from_checkpoint_e2e_with_sentinel`
+	tableName := `resume_checkpoint_e2e_w_sentinel`
 	testutils.RunSQL(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s, _%s_old, _%s_chkpnt, _%s_sentinel`, tableName, tableName, tableName, tableName))
 	table := fmt.Sprintf(`CREATE TABLE %s (
 		id int(11) NOT NULL AUTO_INCREMENT,
@@ -2663,7 +2663,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 
 	go func() {
 		err := runner.Run(ctx)
-		assert.Error(t, err) // it gets interrupted as soon as there is a checkpoint saved.
+		assert.ErrorContains(t, err, "context canceled") // it gets interrupted as soon as there is a checkpoint saved.
 	}()
 
 	// wait until a checkpoint is saved (which means copy is in progress)

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -2228,7 +2228,6 @@ func TestVarcharE2E(t *testing.T) {
 
 func TestSkipDropAfterCutover(t *testing.T) {
 	tableName := `drop_test`
-	oldName := fmt.Sprintf("_%s_old", tableName)
 
 	testutils.RunSQL(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, tableName))
 	table := fmt.Sprintf(`CREATE TABLE %s (
@@ -2256,7 +2255,7 @@ func TestSkipDropAfterCutover(t *testing.T) {
 
 	sql := fmt.Sprintf(
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, oldName)
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.oldTableName())
 	var tableCount int
 	err = m.db.QueryRow(sql).Scan(&tableCount)
 	assert.NoError(t, err)
@@ -2268,7 +2267,6 @@ func TestDropAfterCutover(t *testing.T) {
 	sentinelWaitLimit = 10 * time.Second
 
 	tableName := `drop_test`
-	oldName := fmt.Sprintf("_%s_old", tableName)
 
 	testutils.RunSQL(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, tableName))
 	table := fmt.Sprintf(`CREATE TABLE %s (
@@ -2296,7 +2294,7 @@ func TestDropAfterCutover(t *testing.T) {
 
 	sql := fmt.Sprintf(
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, oldName)
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.oldTableName())
 	var tableCount int
 	err = m.db.QueryRow(sql).Scan(&tableCount)
 	assert.NoError(t, err)
@@ -2366,7 +2364,6 @@ func TestDeferCutOverE2E(t *testing.T) {
 
 	c := make(chan error)
 	tableName := `deferred_cutover_e2e`
-	oldName := fmt.Sprintf("_%s_old", tableName)
 	sentinelTableName := fmt.Sprintf("_%s_sentinel", tableName)
 	checkpointTableName := fmt.Sprintf("_%s_chkpnt", tableName)
 
@@ -2424,7 +2421,7 @@ func TestDeferCutOverE2E(t *testing.T) {
 
 	sql := fmt.Sprintf(
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, oldName)
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.oldTableName())
 	var tableCount int
 	err = db.QueryRow(sql).Scan(&tableCount)
 	assert.NoError(t, err)
@@ -2441,7 +2438,6 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 
 	c := make(chan error)
 	tableName := `deferred_cutover_e2e_stage`
-	oldName := fmt.Sprintf("_%s_old", tableName)
 	sentinelTableName := fmt.Sprintf("_%s_sentinel", tableName)
 	checkpointTableName := fmt.Sprintf("_%s_chkpnt", tableName)
 
@@ -2503,7 +2499,7 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 
 	sql := fmt.Sprintf(
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, oldName)
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.oldTableName())
 	var tableCount int
 	err = db.QueryRow(sql).Scan(&tableCount)
 	assert.NoError(t, err)


### PR DESCRIPTION
* Extends the old table name to include the current timestamp, but only if  `--skip-drop-after-cutover` is used.
  * This helps distinguish old table and prevent multiple old tables from being deleted
  * This has the potential of leaving more orphaned "old" tables in some tests since their names are now dynamic
* Check the table name length early in Preflight checks.  
* Calculates the possible lengths on runtime based on the table suffix formats.

Fixes https://github.com/cashapp/spirit/issues/296