### PR TITLE
prevent concurrent table modifications

### DIFF
--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -1,0 +1,98 @@
+package dbconn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/siddontang/loggers"
+)
+
+var (
+	// getLockTimeout is the timeout for acquiring the GET_LOCK. We set it to 0
+	// because we want to return immediately if the lock is not available
+	getLockTimeout  = 0 * time.Second
+	refreshInterval = 1 * time.Minute
+)
+
+type MetadataLock struct {
+	cancel          context.CancelFunc
+	closeCh         chan error
+	refreshInterval time.Duration
+}
+
+func NewMetadataLock(ctx context.Context, dsn string, lockName string, logger loggers.Advanced) (*MetadataLock, error) {
+
+	mdl := &MetadataLock{
+		refreshInterval: refreshInterval,
+	}
+
+	// Setup the dedicated connection for this lock
+	dbConfig := NewDBConfig()
+	dbConfig.MaxOpenConnections = 1
+	dbConn, err := New(dsn, dbConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Function to acquire the lock
+	getLock := func() error {
+		// https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_get-lock
+		var answer int
+		if err := dbConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, getLockTimeout.Seconds()).Scan(&answer); err != nil {
+			return fmt.Errorf("could not acquire metadata lock: %s", err)
+
+		}
+		if answer == 0 {
+			// 0 means the lock is held by another connection
+			// TODO: we could lookup the connection that holds the lock and report details about it
+			return fmt.Errorf("could not acquire metadata lock: %s, lock is held by another connection", lockName)
+		} else if answer != 1 {
+			// probably we never get here, but just in case
+			return fmt.Errorf("could not acquire metadata lock: %s, GET_LOCK returned: %d", lockName, answer)
+		}
+		return nil
+	}
+
+	// Acquire the lock or return an error immediately
+	logger.Infof("attempting to acquire metadata lock: %s", lockName)
+	if err = getLock(); err != nil {
+		return nil, err
+	}
+	logger.Infof("acquired metadata lock: %s", lockName)
+
+	// Setup background refresh runner
+	ctx, mdl.cancel = context.WithCancel(ctx)
+	mdl.closeCh = make(chan error)
+	go func() {
+		// The only reason to sleep here is to give our tests a chance to override the mdl.refreshInterval
+		time.Sleep(1 * time.Second)
+
+		ticker := time.NewTicker(mdl.refreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				// Close the dedicated connection to release the lock
+				logger.Warnf("releasing metadata lock: %s", lockName)
+				mdl.closeCh <- dbConn.Close()
+				return
+			case <-ticker.C:
+				if err = getLock(); err != nil {
+					logger.Errorf("could not refresh metadata lock: %s", err)
+				}
+				logger.Infof("refreshed metadata lock: %s", lockName)
+			}
+		}
+	}()
+
+	return mdl, nil
+}
+
+func (m *MetadataLock) Close() error {
+	// Cancel the background refresh runner
+	m.cancel()
+
+	// Wait for the dedicated connection to be closed and return its error (if any)
+	return <-m.closeCh
+}

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -2,6 +2,7 @@ package dbconn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,7 +24,7 @@ type MetadataLock struct {
 
 func NewMetadataLock(ctx context.Context, dsn string, lockName string, logger loggers.Advanced) (*MetadataLock, error) {
 	if len(lockName) == 0 {
-		return nil, fmt.Errorf("metadata lock name is empty")
+		return nil, errors.New("metadata lock name is empty")
 	}
 	if len(lockName) > 64 {
 		return nil, fmt.Errorf("metadata lock name is too long: %d, max length is 64", len(lockName))
@@ -47,7 +48,6 @@ func NewMetadataLock(ctx context.Context, dsn string, lockName string, logger lo
 		var answer int
 		if err := dbConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, getLockTimeout.Seconds()).Scan(&answer); err != nil {
 			return fmt.Errorf("could not acquire metadata lock: %s", err)
-
 		}
 		if answer == 0 {
 			// 0 means the lock is held by another connection

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -22,6 +22,12 @@ type MetadataLock struct {
 }
 
 func NewMetadataLock(ctx context.Context, dsn string, lockName string, logger loggers.Advanced) (*MetadataLock, error) {
+	if len(lockName) == 0 {
+		return nil, fmt.Errorf("metadata lock name is empty")
+	}
+	if len(lockName) > 64 {
+		return nil, fmt.Errorf("metadata lock name is too long: %d, max length is 64", len(lockName))
+	}
 
 	mdl := &MetadataLock{
 		refreshInterval: refreshInterval,

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -55,12 +55,12 @@ func TestMetadataLockContextCancel(t *testing.T) {
 func TestMetadataLockRefresh(t *testing.T) {
 	lockName := "test-refresh"
 	logger := logrus.New()
-	mdl, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	mdl, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger, func(mdl *MetadataLock) {
+		// override the refresh interval for faster testing
+		mdl.refreshInterval = 2 * time.Second
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, mdl)
-
-	// override the refresh interval to 5 seconds
-	mdl.refreshInterval = 2 * time.Second
 
 	// wait for the refresh to happen
 	time.Sleep(5 * time.Second)

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -19,18 +19,16 @@ func TestMetadataLock(t *testing.T) {
 
 	// Confirm a second lock cannot be acquired
 	_, err = NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
-	assert.Error(t, err)
 	assert.ErrorContains(t, err, "lock is held by another connection")
 
 	// Close the original mdl
-	err = mdl.Close()
-	assert.NoError(t, err)
+	assert.NoError(t, mdl.Close())
 
 	// Confirm a new lock can be acquired
 	mdl3, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
 	assert.NoError(t, err)
-	err = mdl3.Close()
-	assert.NoError(t, err)
+	assert.NoError(t, mdl3.Close())
+
 }
 
 func TestMetadataLockContextCancel(t *testing.T) {
@@ -52,8 +50,7 @@ func TestMetadataLockContextCancel(t *testing.T) {
 	mdl2, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, mdl2)
-	err = mdl2.Close()
-	assert.NoError(t, err)
+	assert.NoError(t, mdl2.Close())
 }
 
 func TestMetadataLockRefresh(t *testing.T) {
@@ -71,7 +68,6 @@ func TestMetadataLockRefresh(t *testing.T) {
 
 	// Confirm the lock is still held
 	_, err = NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
-	assert.Error(t, err)
 	assert.ErrorContains(t, err, "lock is held by another connection")
 
 	// Close the lock

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -71,6 +71,18 @@ func TestMetadataLockRefresh(t *testing.T) {
 	assert.ErrorContains(t, err, "lock is held by another connection")
 
 	// Close the lock
-	err = mdl.Close()
-	assert.NoError(t, err)
+	assert.NoError(t, mdl.Close())
+}
+
+func TestMetadataLockLength(t *testing.T) {
+	long := "thisisareallylongtablenamethisisareallylongtablenamethisisareallylongtablename"
+	empty := ""
+
+	logger := logrus.New()
+
+	_, err := NewMetadataLock(context.Background(), testutils.DSN(), long, logger)
+	assert.ErrorContains(t, err, "metadata lock name is too long")
+
+	_, err = NewMetadataLock(context.Background(), testutils.DSN(), empty, logger)
+	assert.ErrorContains(t, err, "metadata lock name is empty")
 }

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -1,0 +1,80 @@
+package dbconn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cashapp/spirit/pkg/testutils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadataLock(t *testing.T) {
+	lockName := "test"
+	logger := logrus.New()
+	mdl, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, mdl)
+
+	// Confirm a second lock cannot be acquired
+	_, err = NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "lock is held by another connection")
+
+	// Close the original mdl
+	err = mdl.Close()
+	assert.NoError(t, err)
+
+	// Confirm a new lock can be acquired
+	mdl3, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.NoError(t, err)
+	err = mdl3.Close()
+	assert.NoError(t, err)
+}
+
+func TestMetadataLockContextCancel(t *testing.T) {
+	lockName := "test-cancel"
+
+	logger := logrus.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	mdl, err := NewMetadataLock(ctx, testutils.DSN(), lockName, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, mdl)
+
+	// Cancel the context
+	cancel()
+
+	// Wait for the lock to be released
+	<-mdl.closeCh
+
+	// Confirm the lock is released by acquiring a new one
+	mdl2, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, mdl2)
+	err = mdl2.Close()
+	assert.NoError(t, err)
+}
+
+func TestMetadataLockRefresh(t *testing.T) {
+	lockName := "test-refresh"
+	logger := logrus.New()
+	mdl, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, mdl)
+
+	// override the refresh interval to 5 seconds
+	mdl.refreshInterval = 2 * time.Second
+
+	// wait for the refresh to happen
+	time.Sleep(5 * time.Second)
+
+	// Confirm the lock is still held
+	_, err = NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "lock is held by another connection")
+
+	// Close the lock
+	err = mdl.Close()
+	assert.NoError(t, err)
+}

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -28,7 +28,6 @@ func TestMetadataLock(t *testing.T) {
 	mdl3, err := NewMetadataLock(context.Background(), testutils.DSN(), lockName, logger)
 	assert.NoError(t, err)
 	assert.NoError(t, mdl3.Close())
-
 }
 
 func TestMetadataLockContextCancel(t *testing.T) {

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -2810,3 +2810,63 @@ func TestIndexVisibility(t *testing.T) {
 	assert.Error(t, err)
 	assert.NoError(t, m.Close()) // it's errored, we don't need to try again. We can close.
 }
+
+func TestPreventConcurrentRuns(t *testing.T) {
+	sentinelWaitLimit = 10 * time.Second
+
+	tableName := `prevent_concurrent_runs`
+	sentinelTableName := fmt.Sprintf("_%s_sentinel", tableName)
+	checkpointTableName := fmt.Sprintf("_%s_chkpnt", tableName)
+
+	dropStmt := `DROP TABLE IF EXISTS %s`
+	testutils.RunSQL(t, fmt.Sprintf(dropStmt, tableName))
+	testutils.RunSQL(t, fmt.Sprintf(dropStmt, sentinelTableName))
+	testutils.RunSQL(t, fmt.Sprintf(dropStmt, checkpointTableName))
+
+	table := fmt.Sprintf(`CREATE TABLE %s (id bigint unsigned not null auto_increment, primary key(id))`, tableName)
+
+	testutils.RunSQL(t, table)
+	testutils.RunSQL(t, fmt.Sprintf("insert into %s () values (),(),(),(),(),(),(),(),(),()", tableName))
+	testutils.RunSQL(t, fmt.Sprintf("insert into %s (id) select null from %s a, %s b, %s c limit 1000", tableName, tableName, tableName, tableName))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+	m, err := NewRunner(&Migration{
+		Host:                 cfg.Addr,
+		Username:             cfg.User,
+		Password:             cfg.Passwd,
+		Database:             cfg.DBName,
+		Threads:              4,
+		Table:                tableName,
+		Alter:                "ENGINE=InnoDB",
+		SkipDropAfterCutover: false,
+		DeferCutOver:         true,
+	})
+	assert.NoError(t, err)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = m.Run(context.Background())
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
+	}()
+
+	// While it's waiting, start another run and confirm it fails.
+	time.Sleep(1 * time.Second)
+	m2, err := NewRunner(&Migration{
+		Host:                 cfg.Addr,
+		Username:             cfg.User,
+		Password:             cfg.Passwd,
+		Database:             cfg.DBName,
+		Threads:              4,
+		Table:                tableName,
+		Alter:                "ENGINE=InnoDB",
+		SkipDropAfterCutover: false,
+		DeferCutOver:         false,
+	})
+	assert.NoError(t, err)
+	err = m2.Run(context.Background())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "could not acquire lock")
+}

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -2745,6 +2745,7 @@ func TestIndexVisibility(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, m.usedInplaceDDL) // expected to count as safe.
+	assert.NoError(t, m.Close())
 
 	// Test again with visible
 	m, err = NewRunner(&Migration{
@@ -2760,6 +2761,7 @@ func TestIndexVisibility(t *testing.T) {
 	err = m.Run(context.Background())
 	assert.NoError(t, err)
 	assert.True(t, m.usedInplaceDDL) // expected to count as safe.
+	assert.NoError(t, m.Close())
 
 	// Test again but include an unsafe INPLACE change at the same time.
 	// This won't work by default.
@@ -2791,6 +2793,7 @@ func TestIndexVisibility(t *testing.T) {
 	assert.NoError(t, err)
 	err = m.Run(context.Background())
 	assert.NoError(t, err)
+	assert.NoError(t, m.Close())
 
 	// But even when force inplace is set, we won't be able to do an operation
 	// that requires a full copy. This is important because invisible should

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -2871,5 +2871,5 @@ func TestPreventConcurrentRuns(t *testing.T) {
 	assert.NoError(t, err)
 	err = m2.Run(context.Background())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "could not acquire lock")
+	assert.ErrorContains(t, err, "could not acquire metadata lock")
 }


### PR DESCRIPTION
* Creates a `dbconn.MetadataLock` struct that does a `GET_LOCK` on a dedicated mysql connection and maintains that lock until `Close()` is called or the context passed is is canceled.
* Updated `Runner` to take the metadata lock for the given schema + table before it starts any schema change operations to prevent concurrent Spirit runs against the same table. `Close()` cleans up the lock.

I checked ghost and the GET_LOCK it uses does not contain the table name: https://github.com/github/gh-ost/blob/master/go/logic/applier.go#L852 so it doesn't seem like we will have any benefit to preventing simultaneous ghost and spirit runs on the same table.