### PR TITLE
[#306] Upgrade to go 1.22

### DIFF
--- a/.github/workflows/buildandrun.yml
+++ b/.github/workflows/buildandrun.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
       - name: golangci-lint

--- a/.github/workflows/mysql8.0.28.yml
+++ b/.github/workflows/mysql8.0.28.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/mysql8.yml
+++ b/.github/workflows/mysql8.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/mysql84.yml
+++ b/.github/workflows/mysql84.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/mysql8_rbr_minimal.yml
+++ b/.github/workflows/mysql8_rbr_minimal.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 ## Minimum Requirements
 
-Spirit requires go 1.21 or higher. MySQL version 8.0 and higher is required for performing schema changes.
+Spirit requires go 1.22 or higher. MySQL version 8.0 and higher is required for performing schema changes.
 
 ## Running tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 WORKDIR /app
 COPY ../go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cashapp/spirit
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alecthomas/kong v0.7.1


### PR DESCRIPTION
Resolves https://github.com/cashapp/spirit/issues/306
