### PR TITLE
Reject read only connections to primary nodes

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -3032,6 +3032,10 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	// character_set_client, character_set_connection, character_set_results
 	ops = append(ops, fmt.Sprintf("%s=%s", "charset", "binary"))
 	ops = append(ops, fmt.Sprintf("%s=%s", "collation", "binary"))
+	// So that we recycle the connection if we inadvertently connect to an old primary which is now a read only replica.
+	// This behaviour has been observed during blue/green upgrades and failover on AWS Aurora.
+	// See also: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#rejectreadonly
+	ops = append(ops, fmt.Sprintf("%s=%s", "rejectReadOnly", "true"))
 	dsn = fmt.Sprintf("%s?%s", dsn, strings.Join(ops, "&"))
 	return dsn, nil
 }


### PR DESCRIPTION
So that we recycle the connection if we inadvertently connect to an old primary which is now a read only replica. This behaviour has been observed during blue/green upgrades and failover on AWS Aurora. See also: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#rejectreadonly

Fixes https://github.com/cashapp/spirit/issues/250