### PR TITLE
Add virtual column support

### DIFF
--- a/pkg/checksum/checker.go
+++ b/pkg/checksum/checker.go
@@ -225,8 +225,8 @@ func (c *Checker) replaceChunk(ctx context.Context, chunk *table.Chunk) error {
 	deleteStmt := "DELETE FROM " + c.newTable.QuotedName + " WHERE " + chunk.String()
 	replaceStmt := fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s WHERE %s",
 		c.newTable.QuotedName,
-		utils.IntersectColumns(c.table, c.newTable),
-		utils.IntersectColumns(c.table, c.newTable),
+		utils.IntersectNonGeneratedColumns(c.table, c.newTable),
+		utils.IntersectNonGeneratedColumns(c.table, c.newTable),
 		c.table.QuotedName,
 		chunk.String(),
 	)

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -578,8 +578,8 @@ func (c *Client) createReplaceStmt(replaceKeys []string) statement {
 	if len(replaceKeys) > 0 {
 		replaceStmt = fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE (%s) IN (%s)",
 			c.newTable.QuotedName,
-			utils.IntersectColumns(c.table, c.newTable),
-			utils.IntersectColumns(c.table, c.newTable),
+			utils.IntersectNonGeneratedColumns(c.table, c.newTable),
+			utils.IntersectNonGeneratedColumns(c.table, c.newTable),
 			c.table.QuotedName,
 			table.QuoteColumns(c.table.KeyColumns),
 			c.pksToRowValueConstructor(replaceKeys),

--- a/pkg/row/copier.go
+++ b/pkg/row/copier.go
@@ -132,8 +132,8 @@ func (c *Copier) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 	// resuming from checkpoint we will be re-applying some of the previous executed work.
 	query := fmt.Sprintf("INSERT IGNORE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE %s",
 		c.newTable.QuotedName,
-		utils.IntersectColumns(c.table, c.newTable),
-		utils.IntersectColumns(c.table, c.newTable),
+		utils.IntersectNonGeneratedColumns(c.table, c.newTable),
+		utils.IntersectNonGeneratedColumns(c.table, c.newTable),
 		c.table.QuotedName,
 		chunk.String(),
 	)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,11 +26,11 @@ func HashKey(key []interface{}) string {
 	return strings.Join(pk, PrimaryKeySeparator)
 }
 
-// IntersectColumns returns a string of columns that are in both tables.
-func IntersectColumns(t1, t2 *table.TableInfo) string {
+// IntersectNonGeneratedColumns returns a string of columns that are in both tables
+func IntersectNonGeneratedColumns(t1, t2 *table.TableInfo) string {
 	var intersection []string
-	for _, col := range t1.Columns {
-		for _, col2 := range t2.Columns {
+	for _, col := range t1.NonGeneratedColumns {
+		for _, col2 := range t2.NonGeneratedColumns {
 			if col == col2 {
 				intersection = append(intersection, "`"+col+"`")
 			}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -11,17 +11,17 @@ import (
 func TestIntersectColumns(t *testing.T) {
 	t1 := table.NewTableInfo(nil, "test", "t1")
 	t1new := table.NewTableInfo(nil, "test", "t1_new")
-	t1.Columns = []string{"a", "b", "c"}
-	t1new.Columns = []string{"a", "b", "c"}
-	str := IntersectColumns(t1, t1new)
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
+	str := IntersectNonGeneratedColumns(t1, t1new)
 	assert.Equal(t, "`a`, `b`, `c`", str)
 
-	t1new.Columns = []string{"a", "c"}
-	str = IntersectColumns(t1, t1new)
+	t1new.NonGeneratedColumns = []string{"a", "c"}
+	str = IntersectNonGeneratedColumns(t1, t1new)
 	assert.Equal(t, "`a`, `c`", str)
 
-	t1new.Columns = []string{"a", "c", "d"}
-	str = IntersectColumns(t1, t1new)
+	t1new.NonGeneratedColumns = []string{"a", "c", "d"}
+	str = IntersectNonGeneratedColumns(t1, t1new)
 	assert.Equal(t, "`a`, `c`", str)
 }
 


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/cashapp/spirit/blob/main/.github/CONTRIBUTING.md

Fixes https://github.com/cashapp/spirit/issues/323

We only need to get the intersection of physical columns for copying. This adds support to remove virtual columns from the list to compare, which means virtual columns can be supported fine.