### PR TITLE
dev/test improvement - log test output in json and summarise using tparse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
+FROM golang:1.23 as builder
+
+RUN go install github.com/mfridman/tparse@latest
+
+# copy the installed tparse binary to the final image
 FROM golang:1.23
 
+COPY --from=builder /go/bin/tparse /usr/local/bin/tparse
+
 WORKDIR /app
+
 COPY ../go.mod go.sum ./
+
 RUN go mod download
+
 COPY .. .

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -2,7 +2,7 @@ services:
   mysql:
     image: mysql:8.0.33
     ports: [ '8033:3306' ]
-    # to supress mbind: Operation not permitted in CI
+    # to suppress mbind: Operation not permitted in CI
     # https://stackoverflow.com/a/55706057
     cap_add:
       - SYS_NICE
@@ -21,7 +21,7 @@ services:
   test:
     build:
       context: ../
-    command: go test -race -v ./...
+    command: bash -c "go test -json -race -v ./... | tee /proc/1/fd/1 | tparse -all"
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
### Change summary:
Makes the test summary easy to read/compare.

1. Log test output in `json` format.
2. Json output is sent to the `compose-test-1` containers `stdout/&1`.
3. Then the raw `json` output is piped to `tparse` to summarize the test output.

### Sample output
<img width="699" alt="Screenshot 2025-01-24 at 4 55 58 pm" src="https://github.com/user-attachments/assets/984ffbbb-bed2-49c7-9419-54b31ef80d7e" />
