### PR TITLE
enhance the mdl refresh runner to handle connection closures and temporary network issues resiliently

### DIFF
--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -58,7 +58,6 @@ func TestMetadataLockContextCancel(t *testing.T) {
 func TestMetadataLockRefresh(t *testing.T) {
 	lockTableInfo := table.TableInfo{SchemaName: "test", TableName: "test-refresh"}
 	logger := logrus.New()
-	logger.SetLevel(logrus.DebugLevel)
 
 	mdl, err := NewMetadataLock(context.Background(), testutils.DSN(), &lockTableInfo, logger, func(mdl *MetadataLock) {
 		// override the refresh interval for faster testing


### PR DESCRIPTION
## Change Summary

At the moment - The mdl refresh runner would not work in-case of connection issues or temporary network issues as the current refresh logic using the same dbConn might not be able to acquire the lock. This is because the existing connection might be broken or invalidated, an just reusing it won't help in such scenarios.

## Test Output
Relevant parts of the test output - 
```
{"Time":"2025-01-29T02:37:16.316393094Z","Action":"run","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation"}
{"Time":"2025-01-29T02:37:16.31639501Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"=== RUN   TestMetadataLockRefreshWithConnIssueSimulation\n"}
{"Time":"2025-01-29T02:37:16.318316135Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:16Z\" level=info msg=\"attempting to acquire metadata lock for test.test-refresh\"\n"}
{"Time":"2025-01-29T02:37:16.318621469Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:16Z\" level=info msg=\"acquired metadata lock: test.test-refresh\"\n"}

{"Time":"2025-01-29T02:37:18.320116136Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:18Z\" level=debug msg=\"refreshed metadata lock for test.test-refresh\"\n"}

{"Time":"2025-01-29T02:37:20.319889096Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:20Z\" level=info msg=\"About to close MetadataLock database connection\"\n"}

{"Time":"2025-01-29T02:37:20.320267512Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:20Z\" level=debug msg=\"refreshed metadata lock for test.test-refresh\"\n"}

{"Time":"2025-01-29T02:37:22.319826138Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:22Z\" level=warning msg=\"could not refresh metadata lock: could not acquire metadata lock: sql: database is closed\"\n"}
{"Time":"2025-01-29T02:37:22.324364222Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:22Z\" level=info msg=\"re-acquired metadata lock after re-establishing connection: test.test-refresh\"\n"}

{"Time":"2025-01-29T02:37:24.321437417Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:24Z\" level=debug msg=\"refreshed metadata lock for test.test-refresh\"\n"}

{"Time":"2025-01-29T02:37:25.325791334Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:25Z\" level=info msg=\"attempting to acquire metadata lock for test.test-refresh\"\n"}
{"Time":"2025-01-29T02:37:25.326032125Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:25Z\" level=warning msg=\"could not acquire metadata lock for test.test-refresh, lock is held by another connection\"\n"}

{"Time":"2025-01-29T02:37:25.326140167Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"time=\"2025-01-29T02:37:25Z\" level=warning msg=\"releasing metadata lock for test.test-refresh\"\n"}
{"Time":"2025-01-29T02:37:25.3262225Z","Action":"output","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Output":"--- PASS: TestMetadataLockRefreshWithConnIssueSimulation (9.01s)\n"}
{"Time":"2025-01-29T02:37:25.326246292Z","Action":"pass","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestMetadataLockRefreshWithConnIssueSimulation","Elapsed":9.01}
{"Time":"2025-01-29T02:37:25.326250584Z","Action":"run","Package":"github.com/cashapp/spirit/pkg/dbconn","Test":"TestTableLock"}

```