### PR TITLE
fix --statement bugs

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -90,6 +90,7 @@ func (m *Migration) normalizeOptions() (stmt *statement.AbstractStatement, err e
 		if stmt.Schema != "" && stmt.Schema != m.Database {
 			return nil, errors.New("schema name in statement (`schema`.`table`) does not match --database")
 		}
+		stmt.Schema = m.Database
 	} else {
 		if m.Table == "" {
 			return nil, errors.New("table name is required")
@@ -104,6 +105,7 @@ func (m *Migration) normalizeOptions() (stmt *statement.AbstractStatement, err e
 			return nil, errors.New("could not parse SQL statement: " + fullStatement)
 		}
 		stmt = &statement.AbstractStatement{
+			Schema:    m.Database,
 			Table:     m.Table,
 			Alter:     m.Alter,
 			Statement: fullStatement,

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -50,6 +50,9 @@ func New(statement string) (*AbstractStatement, error) {
 		}
 		normalizedStmt := sb.String()
 		trimLen := len(alterStmt.Table.Name.String()) + 15 // len ALTER TABLE + quotes
+		if len(alterStmt.Table.Schema.String()) > 0 {
+			trimLen += len(alterStmt.Table.Schema.String()) + 3 // len schema + quotes and dot.
+		}
 		return &AbstractStatement{
 			Schema:    alterStmt.Table.Schema.String(),
 			Table:     alterStmt.Table.Name.String(),

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -12,6 +12,12 @@ func TestExtractFromStatement(t *testing.T) {
 	assert.Equal(t, "t1", abstractStmt.Table)
 	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt.Alter)
 
+	abstractStmt, err = New("ALTER TABLE test.t1 ADD INDEX (something)")
+	assert.NoError(t, err)
+	assert.Equal(t, "test", abstractStmt.Schema)
+	assert.Equal(t, "t1", abstractStmt.Table)
+	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt.Alter)
+
 	abstractStmt, err = New("ALTER TABLE t1aaaa ADD COLUMN newcol int")
 	assert.NoError(t, err)
 	assert.Equal(t, "t1aaaa", abstractStmt.Table)


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/cashapp/spirit/blob/main/.github/CONTRIBUTING.md

There are a few bugs in https://github.com/cashapp/spirit/pull/375 

- Attempting as INSTANT or INPLACE doesn't work when --statement is used. This is because it depends on the `--alter` specified by the user, and not the stmt.Alter. For consistency I've unified Alter and Schema to come from stmt.
- Extracting the ALTER portion of an alter statement was inaccurate when the schema name was specified.