### PR TITLE
Fix non printable characters in checkpoint

### DIFF
--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -103,7 +103,9 @@ func (b *Boundary) valuesString() string {
 		// We have to *also* quote numeric types to avoid JSON float behavior
 		// See Issue #125; this doesn't apply to string types
 		// because they are already quoted by datum.String()
-		if v.IsNumeric() {
+		// We also force-quote binary strings, because there is no JSON handling
+		// for a hex values, and it needs quoting in this context.
+		if v.IsNumeric() || v.IsBinaryString() {
 			vals[i] = fmt.Sprintf(`"%s"`, v)
 		} else {
 			vals[i] = v.String()

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -1,9 +1,11 @@
 package table
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
+	"unicode/utf8"
 
 	"github.com/cashapp/spirit/pkg/dbconn/sqlescape"
 )
@@ -81,6 +83,16 @@ func datumValFromString(val string, tp datumTp) (interface{}, error) {
 		return i, nil
 	} else if tp == unsignedType {
 		return strconv.ParseUint(val, 10, 64)
+	}
+	// If it starts with 0x then it's a binary string. If it was actually
+	// a string that contained 0x, then we have encoded it as hex anyway.
+	// see pkg/table/chunk.go:valuesString()
+	if len(val) > 2 && val[0:2] == "0x" {
+		tmp, err := hex.DecodeString(val[2:])
+		if err != nil {
+			return nil, err
+		}
+		return string(tmp), nil
 	}
 	return val, nil
 }
@@ -166,15 +178,32 @@ func (d Datum) Range(d2 Datum) uint64 {
 
 // String returns the datum as a SQL escaped string
 func (d Datum) String() string {
-	if !d.IsNumeric() {
-		return "\"" + sqlescape.EscapeString(d.Val.(string)) + "\""
+	if d.IsNil() {
+		return "NULL"
 	}
-	return fmt.Sprintf("%v", d.Val)
+	if d.IsNumeric() {
+		return fmt.Sprintf("%v", d.Val)
+	}
+	s, ok := d.Val.(string)
+	if ok && d.IsBinaryString() {
+		return fmt.Sprintf("0x%x", s)
+	} else if ok {
+		return "\"" + sqlescape.EscapeString(s) + "\""
+	}
+	panic("can not convert datum to string")
 }
 
 // IsNumeric checks if it's signed or unsigned
 func (d Datum) IsNumeric() bool {
 	return d.Tp == signedType || d.Tp == unsignedType
+}
+
+func (d Datum) IsBinaryString() bool {
+	s, ok := d.Val.(string)
+	// ok is true and it's not a valid utf8 string OR the first 2 characters of s are 0x
+	// this is because we *must* encode 0x strings like they are binary because
+	// otherwise it can cause corruption on restoring JSON.
+	return ok && (!utf8.ValidString(s) || (len(s) > 2 && s[0:2] == "0x"))
 }
 
 func (d Datum) IsNil() bool {

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cashapp/spirit/pkg/dbconn/sqlescape"
@@ -87,7 +88,7 @@ func datumValFromString(val string, tp datumTp) (interface{}, error) {
 	// If it starts with 0x then it's a binary string. If it was actually
 	// a string that contained 0x, then we have encoded it as hex anyway.
 	// see pkg/table/chunk.go:valuesString()
-	if len(val) > 2 && val[0:2] == "0x" {
+	if strings.HasPrefix(val, "0x") {
 		tmp, err := hex.DecodeString(val[2:])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/cashapp/spirit/blob/main/.github/CONTRIBUTING.md

This fixes https://github.com/cashapp/spirit/issues/381  

- Checkpoints with non-printable values are hex encoded (and quoted) and if it looks like a hex value on restore, it's decoded. Special care is taken on encoding to force-encode strings that start with the hex prefix.
- Non printable values are hex encoded in log output.