### PR TITLE
migrate to go 1.24 and golangci-lint v2

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.24
       - name: Checkout code
         uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.62.2
+          version: v2.0.2
           args: --timeout=2m

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v2.0.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,79 +1,90 @@
+version: "2"
 run:
   tests: true
-
-output:
-  print-issued-lines: false
-
 linters:
-  enable-all: true
+  default: all
   disable:
-    - gomoddirectives
-    - tagalign
+    - cyclop
     - depguard
-    - mnd
-    - musttag
-    - nonamedreturns
-    - exhaustruct
-    - varnamelen
     - dupl
+    - err113
+    - errorlint
+    - exhaustruct
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
     - gochecknoinits
+    - gocognit
+    - goconst
     - gocritic
     - gocyclo
-    - ireturn
-    - prealloc
+    - godot
+    - godox
+    - gomoddirectives
+    - goprintffuncname
     - gosec
+    - ireturn
+    - lll
+    - maintidx
+    - mnd
+    - musttag
+    - nestif
+    - nilnil
+    - nlreturn
+    - nonamedreturns
+    - paralleltest
+    - prealloc
     - promlinter
     - revive
-    - forcetypeassert
-    - ireturn
-    - maintidx
-    - nilnil
-    - lll
-    - gochecknoglobals
-    - wsl
-    - funlen
-    - gocognit
-    - goprintffuncname
-    - paralleltest
-    - nlreturn
-    - err113
-    - testpackage
-    - wrapcheck
-    - forbidigo
-    - gci
-    - godot
-    - gofumpt
-    - cyclop
-    - errorlint
-    - nestif
+    - tagalign
     - tagliatelle
+    - testpackage
     - thelper
-    - godox
-    - goconst
-    - exportloopref
-
-linters-settings:
-  dupl:
-    threshold: 100
-  gocyclo:
-    min-complexity: 20
-  exhaustive:
-    default-signifies-exhaustive: true
-  testifylint:
-    enable-all: true
-    disable:
-      - suite-thelper # this is disabled by default
-      - float-compare
-      - require-error
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - '^(G104|G204):'
-    # Very commonly not checked.
-    - 'Error return value of .(.*\.Help|.*\.MarkFlagRequired|(os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked'
-    - 'exported method (.*\.MarshalJSON|.*\.UnmarshalJSON) should have comment or be unexported'
-    - 'composite literal uses unkeyed fields'
-    - 'bad syntax for struct tag key'
-    - 'bad syntax for struct tag pair'
-    - 'result .* \(error\) is always nil'
+    - varnamelen
+    - wrapcheck
+    - wsl
+  settings:
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: true
+    gocyclo:
+      min-complexity: 20
+    testifylint:
+      enable-all: true
+      disable:
+        - suite-thelper
+        - float-compare
+        - require-error
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: '^(G104|G204):'
+      - path: (.+)\.go$
+        text: Error return value of .(.*\.Help|.*\.MarkFlagRequired|(os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+      - path: (.+)\.go$
+        text: exported method (.*\.MarshalJSON|.*\.UnmarshalJSON) should have comment or be unexported
+      - path: (.+)\.go$
+        text: composite literal uses unkeyed fields
+      - path: (.+)\.go$
+        text: bad syntax for struct tag key
+      - path: (.+)\.go$
+        text: bad syntax for struct tag pair
+      - path: (.+)\.go$
+        text: result .* \(error\) is always nil
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 ## Minimum Requirements
 
-Spirit requires go 1.23 or higher. MySQL version 8.0 and higher is required for performing schema changes.
+Spirit requires go 1.24 or higher. MySQL version 8.0 and higher is required for performing schema changes.
 
 ## Running tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 RUN go install github.com/mfridman/tparse@latest
 
 # copy the installed tparse binary to the final image
-FROM golang:1.23
+FROM golang:1.24
 
 COPY --from=builder /go/bin/tparse /usr/local/bin/tparse
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cashapp/spirit
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/alecthomas/kong v0.7.1

--- a/pkg/check/check_test.go
+++ b/pkg/check/check_test.go
@@ -28,7 +28,7 @@ func TestCheckAPI(t *testing.T) {
 	assert.Len(t, checks, checkLen+1)
 
 	assert.Equal(t, "test", testVal)
-	err := RunChecks(context.Background(), Resources{}, logrus.New(), ScopeTesting)
+	err := RunChecks(t.Context(), Resources{}, logrus.New(), ScopeTesting)
 	assert.NoError(t, err)
 	assert.Equal(t, "newval", testVal)
 }

--- a/pkg/check/configuration.go
+++ b/pkg/check/configuration.go
@@ -40,7 +40,7 @@ func configurationCheck(ctx context.Context, r Resources, logger loggers.Advance
 		// This is the auto-inc lock. It won't show up in SHOW PROCESSLIST that they are serial.
 		logger.Warn("innodb_autoinc_lock_mode != 2. This will cause the migration to run slower than expected because concurrent inserts to the new table will be serialized.")
 	}
-	if !(binlogRowImage == "FULL" || binlogRowImage == "MINIMAL") {
+	if binlogRowImage != "FULL" && binlogRowImage != "MINIMAL" {
 		// This might not be required, but these are the only options that have been tested so far.
 		// To keep the testing scope reduced for now, it is required.
 		return errors.New("binlog_row_image must be FULL or MINIMAL")

--- a/pkg/check/configuration_test.go
+++ b/pkg/check/configuration_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -20,7 +19,7 @@ func TestConfiguration(t *testing.T) {
 		Table: &table.TableInfo{TableName: "test", SchemaName: "test"},
 	}
 
-	err = configurationCheck(context.Background(), r, logrus.New())
+	err = configurationCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // all looks good of course.
 
 	// Current binlog row image format.
@@ -33,7 +32,7 @@ func TestConfiguration(t *testing.T) {
 	_, err = db.Exec("SET GLOBAL binlog_row_image = 'NOBLOB'")
 	assert.NoError(t, err)
 
-	err = configurationCheck(context.Background(), r, logrus.New())
+	err = configurationCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 
 	// restore the binlog row image format.

--- a/pkg/check/dropadd_test.go
+++ b/pkg/check/dropadd_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/statement"
@@ -14,11 +13,11 @@ func TestDropAdd(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT"),
 	}
-	err = dropAddCheck(context.Background(), r, logrus.New())
+	err = dropAddCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "column b is mentioned 2 times in the same statement")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 DROP b1, ADD b2 INT")
-	err = dropAddCheck(context.Background(), r, logrus.New())
+	err = dropAddCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err)
 }

--- a/pkg/check/foreignkey_test.go
+++ b/pkg/check/foreignkey_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -17,12 +16,12 @@ func TestAddForeignKey(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 ADD FOREIGN KEY (customer_id) REFERENCES customers (id)"),
 	}
-	err = addForeignKeyCheck(context.Background(), r, logrus.New())
+	err = addForeignKeyCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // add foreign key
 	assert.ErrorContains(t, err, "adding foreign key constraints is not supported")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 DROP COLUMN foo")
-	err = addForeignKeyCheck(context.Background(), r, logrus.New())
+	err = addForeignKeyCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // regular DDL
 }
 
@@ -59,18 +58,18 @@ func TestHasForeignKey(t *testing.T) {
 		Table:     &table.TableInfo{SchemaName: "test", TableName: "customers"},
 		Statement: statement.MustNew("ALTER TABLE customers ENGINE=innodb"),
 	}
-	err = hasForeignKeysCheck(context.Background(), r, logrus.New())
+	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // already has foreign keys.
 
 	r.Table.TableName = "customer_contacts"
 	r.Statement = statement.MustNew("ALTER TABLE customer_contacts ENGINE=innodb")
-	err = hasForeignKeysCheck(context.Background(), r, logrus.New())
+	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // already has foreign keys.
 
 	_, err = db.Exec(`drop table if exists customer_contacts`)
 	assert.NoError(t, err)
 	r.Table.TableName = "customers"
 	r.Statement = statement.MustNew("ALTER TABLE customers ENGINE=innodb")
-	err = hasForeignKeysCheck(context.Background(), r, logrus.New())
+	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // no longer said to have foreign keys.
 }

--- a/pkg/check/illegalclause_test.go
+++ b/pkg/check/illegalclause_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/statement"
@@ -13,22 +12,22 @@ func TestIllegalClauseCheck(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 ADD INDEX (b), ALGORITHM=INPLACE"),
 	}
-	err := illegalClauseCheck(context.Background(), r, logrus.New())
+	err := illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, ALGORITHM=INPLACE, LOCK=shared")
-	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, lock=none")
-	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 engine=innodb, algorithm=copy")
-	err = illegalClauseCheck(context.Background(), r, logrus.New())
+	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 }

--- a/pkg/check/primarykey_test.go
+++ b/pkg/check/primarykey_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/statement"
@@ -13,10 +12,10 @@ func TestPrimaryKey(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (anothercol)"),
 	}
-	err := primaryKeyCheck(context.Background(), r, logrus.New())
+	err := primaryKeyCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // drop primary key
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")
-	err = primaryKeyCheck(context.Background(), r, logrus.New())
+	err = primaryKeyCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // safe modification
 }

--- a/pkg/check/privileges.go
+++ b/pkg/check/privileges.go
@@ -48,7 +48,7 @@ func privilegesCheck(ctx context.Context, r Resources, logger loggers.Advanced) 
 		if strings.Contains(grant, fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.*", r.Table.SchemaName)) {
 			foundDBAll = true
 		}
-		if strings.Contains(grant, fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.*", strings.Replace(r.Table.SchemaName, "_", "\\_", -1))) {
+		if strings.Contains(grant, fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.*", strings.ReplaceAll(r.Table.SchemaName, "_", "\\_"))) {
 			foundDBAll = true
 		}
 		if stringContainsAll(grant, `ALTER`, `CREATE`, `DELETE`, `DROP`, `INDEX`, `INSERT`, `LOCK TABLES`, `SELECT`, `TRIGGER`, `UPDATE`, ` ON *.*`) {

--- a/pkg/check/privileges_test.go
+++ b/pkg/check/privileges_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -37,19 +36,19 @@ func TestPrivileges(t *testing.T) {
 		DB:    lowPrivDB,
 		Table: &table.TableInfo{TableName: "test", SchemaName: "test"},
 	}
-	err = privilegesCheck(context.Background(), r, logrus.New())
+	err = privilegesCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // privileges fail, since user has nothing granted.
 
 	_, err = db.Exec("GRANT ALL ON test.* TO testprivsuser")
 	assert.NoError(t, err)
 
-	err = privilegesCheck(context.Background(), r, logrus.New())
+	err = privilegesCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // still not enough, needs replication client
 
 	_, err = db.Exec("GRANT REPLICATION CLIENT, REPLICATION SLAVE, RELOAD ON *.* TO testprivsuser")
 	assert.NoError(t, err)
 
-	err = privilegesCheck(context.Background(), r, logrus.New())
+	err = privilegesCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // still not enough, needs replication client and replication slave
 
 	// Test the root user
@@ -57,6 +56,6 @@ func TestPrivileges(t *testing.T) {
 		DB:    db,
 		Table: &table.TableInfo{TableName: "test", SchemaName: "test"},
 	}
-	err = privilegesCheck(context.Background(), r, logrus.New())
+	err = privilegesCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // privileges work fine
 }

--- a/pkg/check/rename_test.go
+++ b/pkg/check/rename_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/statement"
@@ -14,25 +13,25 @@ func TestRename(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 RENAME TO newtablename"),
 	}
-	err := renameCheck(context.Background(), r, logrus.New())
+	err := renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO c2")
-	err = renameCheck(context.Background(), r, logrus.New())
+	err = renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c2 VARCHAR(100)")
-	err = renameCheck(context.Background(), r, logrus.New())
+	err = renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c1 VARCHAR(100)") //nolint: dupword
-	err = renameCheck(context.Background(), r, logrus.New())
+	err = renameCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err)
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")
-	err = renameCheck(context.Background(), r, logrus.New())
+	err = renameCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // safe modification
 }

--- a/pkg/check/replicahealth_test.go
+++ b/pkg/check/replicahealth_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -18,13 +17,13 @@ func TestReplicaHealth(t *testing.T) {
 		Table:     &table.TableInfo{TableName: "test"},
 		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename"),
 	}
-	err := replicaHealth(context.Background(), r, logrus.New())
+	err := replicaHealth(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // if no replica, it returns no error.
 
 	// use a non-replica. this will return an error.
 	r.Replica, err = sql.Open("mysql", testutils.DSN())
 	assert.NoError(t, err)
-	err = replicaHealth(context.Background(), r, logrus.New())
+	err = replicaHealth(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "replica is not healthy")
 
@@ -35,13 +34,13 @@ func TestReplicaHealth(t *testing.T) {
 	}
 	r.Replica, err = sql.Open("mysql", replicaDSN)
 	assert.NoError(t, err)
-	err = replicaHealth(context.Background(), r, logrus.New())
+	err = replicaHealth(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // all looks good of course.
 
 	// use a completely invalid DSN.
 	// golang sql.Open lazy loads, so this is possible.
 	r.Replica, err = sql.Open("mysql", "msandbox:msandbox@tcp(127.0.0.1:22)/test")
 	assert.NoError(t, err)
-	err = replicaHealth(context.Background(), r, logrus.New())
+	err = replicaHealth(t.Context(), r, logrus.New())
 	assert.Error(t, err) // invalid
 }

--- a/pkg/check/replicaprivileges_test.go
+++ b/pkg/check/replicaprivileges_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -22,11 +21,11 @@ func TestReplicaPrivileges(t *testing.T) {
 		Table:     &table.TableInfo{TableName: "test"},
 		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename"),
 	}
-	err := replicaPrivilegeCheck(context.Background(), r, logrus.New())
+	err := replicaPrivilegeCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // if no replica, it returns no error.
 
 	r.Replica, err = sql.Open("mysql", replicaDSN)
 	assert.NoError(t, err) // no error
-	err = replicaPrivilegeCheck(context.Background(), r, logrus.New())
+	err = replicaPrivilegeCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // user has privileges
 }

--- a/pkg/check/settings_test.go
+++ b/pkg/check/settings_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -27,27 +26,27 @@ func TestSettings(t *testing.T) {
 		r.ReplicaMaxLag = time.Second * 120
 	}
 
-	err := settingsCheck(context.Background(), r, logrus.New())
+	err := settingsCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // all looks good
 
 	r.Threads = 0
-	err = settingsCheck(context.Background(), r, logrus.New())
+	err = settingsCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 
 	r.Threads = 65
-	err = settingsCheck(context.Background(), r, logrus.New())
+	err = settingsCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 
 	r.Threads = 2
-	err = settingsCheck(context.Background(), r, logrus.New())
+	err = settingsCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // all looks good
 
 	r.TargetChunkTime = time.Second * 6
-	err = settingsCheck(context.Background(), r, logrus.New())
+	err = settingsCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 
 	r.TargetChunkTime = time.Second * 4
 	r.ReplicaMaxLag = time.Second * 5
-	err = settingsCheck(context.Background(), r, logrus.New())
+	err = settingsCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 }

--- a/pkg/check/tablename.go
+++ b/pkg/check/tablename.go
@@ -34,14 +34,14 @@ func init() {
 
 	// Calculate the number of extra characters needed table names with all possible formats
 	for _, format := range []string{NameFormatSentinel, NameFormatCheckpoint, NameFormatNew, NameFormatOld} {
-		extraChars := len(strings.Replace(format, "%s", "", -1))
+		extraChars := len(strings.ReplaceAll(format, "%s", ""))
 		if extraChars > NameFormatNormalExtraChars {
 			NameFormatNormalExtraChars = extraChars
 		}
 	}
 
 	// Calculate the number of extra characters needed for table names with the old timestamp format
-	NameFormatTimestampExtraChars = len(strings.Replace(NameFormatOldTimeStamp, "%s", "", -1)) + len(NameFormatTimestamp)
+	NameFormatTimestampExtraChars = len(strings.ReplaceAll(NameFormatOldTimeStamp, "%s", "")) + len(NameFormatTimestamp)
 }
 
 func tableNameCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {

--- a/pkg/check/tablename_test.go
+++ b/pkg/check/tablename_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/table"
@@ -27,7 +26,7 @@ func TestCheckTableName(t *testing.T) {
 			},
 			SkipDropAfterCutover: skipDropAfterCutover,
 		}
-		return tableNameCheck(context.Background(), r, logrus.New())
+		return tableNameCheck(t.Context(), r, logrus.New())
 	}
 
 	assert.NoError(t, testTableName("a", false))

--- a/pkg/check/version_test.go
+++ b/pkg/check/version_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestVersion(t *testing.T) {
 		Username: cfg.User,
 		Password: cfg.Passwd,
 	}
-	err = versionCheck(context.Background(), r, logrus.New())
+	err = versionCheck(t.Context(), r, logrus.New())
 	if isMySQL8(db) {
 		assert.NoError(t, err) // all looks good of course.
 	} else {

--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -1,7 +1,6 @@
 package checksum
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -29,9 +28,9 @@ func TestBasicChecksum(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "basic_checksum")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_basic_checksum_new")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -48,7 +47,7 @@ func TestBasicChecksum(t *testing.T) {
 
 	assert.Nil(t, checker.recentValue)
 	assert.Equal(t, "TBD", checker.RecentValue())
-	assert.NoError(t, checker.Run(context.Background()))
+	assert.NoError(t, checker.Run(t.Context()))
 	assert.Equal(t, "TBD", checker.RecentValue()) // still TBD because its a 1 and done chunker.
 }
 
@@ -64,9 +63,9 @@ func TestBasicValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "basic_validation")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "basic_validation2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -101,9 +100,9 @@ func TestFixCorrupt(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "fixcorruption_t1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_fixcorruption_t1_new")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -119,14 +118,14 @@ func TestFixCorrupt(t *testing.T) {
 	config.FixDifferences = true
 	checker, err := NewChecker(db, t1, t2, feed, config)
 	assert.NoError(t, err)
-	err = checker.Run(context.Background())
+	err = checker.Run(t.Context())
 	assert.NoError(t, err) // yes there is corruption, but it was fixed.
 	assert.Equal(t, uint64(1), checker.DifferencesFound())
 
 	// If we run the checker again, it will report zero differences.
 	checker2, err := NewChecker(db, t1, t2, feed, config)
 	assert.NoError(t, err)
-	err = checker2.Run(context.Background())
+	err = checker2.Run(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), checker2.DifferencesFound())
 }
@@ -144,9 +143,9 @@ func TestCorruptChecksum(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "chkpcorruptt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_chkpcorruptt1_new")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -160,7 +159,7 @@ func TestCorruptChecksum(t *testing.T) {
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
-	err = checker.Run(context.Background())
+	err = checker.Run(t.Context())
 	assert.ErrorContains(t, err, "checksum mismatch")
 }
 
@@ -176,9 +175,9 @@ func TestBoundaryCases(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "checkert1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_checkert1_new")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -192,13 +191,13 @@ func TestBoundaryCases(t *testing.T) {
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
-	assert.Error(t, checker.Run(context.Background()))
+	assert.Error(t, checker.Run(t.Context()))
 
 	// UPDATE t1 to also be NULL
 	testutils.RunSQL(t, "UPDATE checkert1 SET c = NULL")
 	checker, err = NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(context.Background()))
+	assert.NoError(t, checker.Run(t.Context()))
 }
 
 func TestChangeDataTypeDatetime(t *testing.T) {
@@ -240,9 +239,9 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "tdatetime")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tdatetime_new")
-	assert.NoError(t, t2.SetInfo(context.TODO())) // fails
+	assert.NoError(t, t2.SetInfo(t.Context())) // fails
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -256,7 +255,7 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(context.Background())) // fails
+	assert.NoError(t, checker.Run(t.Context())) // fails
 }
 
 func TestFromWatermark(t *testing.T) {
@@ -271,9 +270,9 @@ func TestFromWatermark(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "tfromwatermark")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tfromwatermark_new")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	logger := logrus.New()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
@@ -289,5 +288,5 @@ func TestFromWatermark(t *testing.T) {
 	config.Watermark = "{\"Key\":[\"a\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"2\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"3\"],\"Inclusive\":false}}"
 	checker, err := NewChecker(db, t1, t2, feed, config)
 	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(context.Background()))
+	assert.NoError(t, checker.Run(t.Context()))
 }

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -46,7 +46,7 @@ func TestNewDSN(t *testing.T) {
 	dsn = "invalid"
 	resp, err = newDSN(dsn, NewDBConfig())
 	assert.Error(t, err)
-	assert.Equal(t, "", resp)
+	assert.Empty(t, resp)
 }
 
 func TestNewConn(t *testing.T) {

--- a/pkg/dbconn/sqlescape/utils_test.go
+++ b/pkg/dbconn/sqlescape/utils_test.go
@@ -91,8 +91,8 @@ func TestEscapeBackslash(t *testing.T) {
 		},
 		{
 			name:   "chinese",
-			input:  []byte("中文?"),
-			output: []byte("中文?"),
+			input:  []byte("中文?"), //nolint:gosmopolitan
+			output: []byte("中文?"), //nolint:gosmopolitan
 		},
 	}
 	for _, v := range tests {

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -1,7 +1,6 @@
 package dbconn
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -16,25 +15,25 @@ func TestTrxPool(t *testing.T) {
 	defer db.Close()
 	config := NewDBConfig()
 	config.LockWaitTimeout = 10
-	err = Exec(context.Background(), db, "DROP TABLE IF EXISTS test.trxpool")
+	err = Exec(t.Context(), db, "DROP TABLE IF EXISTS test.trxpool")
 	assert.NoError(t, err)
-	err = Exec(context.Background(), db, "CREATE TABLE test.trxpool (id INT NOT NULL PRIMARY KEY, colb int)")
+	err = Exec(t.Context(), db, "CREATE TABLE test.trxpool (id INT NOT NULL PRIMARY KEY, colb int)")
 	assert.NoError(t, err)
 
 	stmts := []string{
 		"INSERT INTO test.trxpool (id, colb) VALUES (1, 1)",
 		"INSERT INTO test.trxpool (id, colb) VALUES (2, 2)",
 	}
-	_, err = RetryableTransaction(context.Background(), db, true, config, stmts...)
+	_, err = RetryableTransaction(t.Context(), db, true, config, stmts...)
 	assert.NoError(t, err)
 
 	// Test that the transaction pool is working.
-	pool, err := NewTrxPool(context.Background(), db, 2, config)
+	pool, err := NewTrxPool(t.Context(), db, 2, config)
 	assert.NoError(t, err)
 
 	// The pool is all repeatable-read transactions, so if I insert new rows
 	// They can't be visible.
-	_, err = RetryableTransaction(context.Background(), db, true, config, "INSERT INTO test.trxpool (id, colb) VALUES (3, 3)")
+	_, err = RetryableTransaction(t.Context(), db, true, config, "INSERT INTO test.trxpool (id, colb) VALUES (3, 3)")
 	assert.NoError(t, err)
 
 	trx1, err := pool.Get()

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -1,7 +1,6 @@
 package migration
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ func TestCutOver(t *testing.T) {
 	assert.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "cutovert1")
-	assert.NoError(t, t1.SetInfo(context.Background())) // required to extract PK.
+	assert.NoError(t, t1.SetInfo(t.Context())) // required to extract PK.
 	t1new := table.NewTableInfo(db, "test", "_cutovert1_new")
 	t1old := "_cutovert1_old"
 	logger := logrus.New()
@@ -57,7 +56,7 @@ func TestCutOver(t *testing.T) {
 	cutover, err := NewCutOver(db, t1, t1new, t1old, feed, dbconn.NewDBConfig(), logger)
 	assert.NoError(t, err)
 
-	err = cutover.Run(context.Background())
+	err = cutover.Run(t.Context())
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, db.Stats().InUse) // all connections are returned
@@ -101,7 +100,7 @@ func TestMDLLockFails(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "mdllocks")
-	assert.NoError(t, t1.SetInfo(context.Background())) // required to extract PK.
+	assert.NoError(t, t1.SetInfo(t.Context())) // required to extract PK.
 	t1new := table.NewTableInfo(db, "test", "_mdllocks_new")
 	t1old := "test_old"
 	logger := logrus.New()
@@ -120,7 +119,7 @@ func TestMDLLockFails(t *testing.T) {
 
 	// Before we cutover, we READ LOCK the table.
 	// This will not fail the table lock but it will fail the rename.
-	trx, err := db.BeginTx(context.TODO(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	trx, err := db.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	assert.NoError(t, err)
 	_, err = trx.Exec("LOCK TABLES mdllocks READ")
 	assert.NoError(t, err)
@@ -128,7 +127,7 @@ func TestMDLLockFails(t *testing.T) {
 	// Start the cutover. It will retry in a loop and fail
 	// after about 15 seconds (3 sec timeout * 5 retries)
 	// or in 5.7 it might fail because it can't find the RENAME in the processlist.
-	err = cutover.Run(context.Background())
+	err = cutover.Run(t.Context())
 	assert.Error(t, err)
 	assert.NoError(t, trx.Rollback())
 }
@@ -155,7 +154,7 @@ func TestInvalidOptions(t *testing.T) {
 	_, err = NewCutOver(db, nil, nil, "", nil, dbconn.NewDBConfig(), logger)
 	assert.Error(t, err)
 	t1 := table.NewTableInfo(db, "test", "invalid_t1")
-	assert.NoError(t, t1.SetInfo(context.Background())) // required to extract PK.
+	assert.NoError(t, t1.SetInfo(t.Context())) // required to extract PK.
 	t1new := table.NewTableInfo(db, "test", "_invalid_t1_new")
 	t1old := "test_old"
 	cfg, err := mysql.ParseDSN(testutils.DSN())

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -445,7 +445,7 @@ func TestCreateIndexIsRewritten(t *testing.T) {
 	testutils.RunSQL(t, tbl)
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
-	require.NotEqual(t, "", cfg.DBName)
+	require.NotEmpty(t, cfg.DBName)
 	migration := &Migration{
 		Host:      cfg.Addr,
 		Username:  cfg.User,

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -43,8 +43,8 @@ func TestVarcharNonBinaryComparable(t *testing.T) {
 		Table:    "nonbinarycompatt1",
 		Alter:    "ENGINE=InnoDB",
 	})
-	assert.NoError(t, err)                         // everything is specified.
-	assert.NoError(t, m.Run(context.Background())) // it's a non-binary comparable type (varchar)
+	assert.NoError(t, err)                // everything is specified.
+	assert.NoError(t, m.Run(t.Context())) // it's a non-binary comparable type (varchar)
 	assert.NoError(t, m.Close())
 }
 
@@ -69,7 +69,7 @@ func TestPartitioningSyntax(t *testing.T) {
 		Alter:    "PARTITION BY KEY() PARTITIONS 8",
 	})
 	assert.NoError(t, err)
-	assert.NoError(t, m.Run(context.Background()))
+	assert.NoError(t, m.Run(t.Context()))
 	assert.NoError(t, m.Close())
 }
 
@@ -93,9 +93,9 @@ func TestVarbinary(t *testing.T) {
 		Table:    "varbinaryt1",
 		Alter:    "ENGINE=InnoDB",
 	})
-	assert.NoError(t, err)                         // everything is specified correctly.
-	assert.NoError(t, m.Run(context.Background())) // varbinary is compatible.
-	assert.False(t, m.usedInstantDDL)              // not possible
+	assert.NoError(t, err)                // everything is specified correctly.
+	assert.NoError(t, m.Run(t.Context())) // varbinary is compatible.
+	assert.False(t, m.usedInstantDDL)     // not possible
 	assert.NoError(t, m.Close())
 }
 
@@ -120,9 +120,9 @@ func TestDataFromBadSqlMode(t *testing.T) {
 		Table:    "badsqlt1",
 		Alter:    "ENGINE=InnoDB",
 	})
-	assert.NoError(t, err)                         // everything is specified correctly.
-	assert.NoError(t, m.Run(context.Background())) // pk is compatible.
-	assert.False(t, m.usedInstantDDL)              // not possible
+	assert.NoError(t, err)                // everything is specified correctly.
+	assert.NoError(t, m.Run(t.Context())) // pk is compatible.
+	assert.False(t, m.usedInstantDDL)     // not possible
 	assert.NoError(t, m.Close())
 }
 
@@ -146,8 +146,8 @@ func TestChangeDatatypeNoData(t *testing.T) {
 		Table:    "cdatatypemytable",
 		Alter:    "CHANGE b b INT", //nolint: dupword
 	})
-	assert.NoError(t, err)                         // everything is specified correctly.
-	assert.NoError(t, m.Run(context.Background())) // no data so no truncation is possible.
+	assert.NoError(t, err)                // everything is specified correctly.
+	assert.NoError(t, m.Run(t.Context())) // no data so no truncation is possible.
 	assert.False(t, m.usedInstantDDL)
 	assert.NoError(t, m.Close())
 }
@@ -173,8 +173,8 @@ func TestChangeDatatypeDataLoss(t *testing.T) {
 		Table:    "cdatalossmytable",
 		Alter:    "CHANGE b b INT", //nolint: dupword
 	})
-	assert.NoError(t, err)                       // everything is specified correctly.
-	assert.Error(t, m.Run(context.Background())) // value 'b' can no convert cleanly to int.
+	assert.NoError(t, err)              // everything is specified correctly.
+	assert.Error(t, m.Run(t.Context())) // value 'b' can no convert cleanly to int.
 	assert.NoError(t, m.Close())
 }
 
@@ -199,7 +199,7 @@ func TestOnline(t *testing.T) {
 		Alter:    "CHANGE COLUMN b b int(11) NOT NULL", //nolint: dupword
 	})
 	assert.NoError(t, err)
-	assert.NoError(t, m.Run(context.TODO()))
+	assert.NoError(t, m.Run(t.Context()))
 	assert.False(t, m.usedInplaceDDL) // not possible
 	assert.NoError(t, m.Close())
 
@@ -222,7 +222,7 @@ func TestOnline(t *testing.T) {
 		Alter:    "ADD c int(11) NOT NULL",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInplaceDDL) // uses instant DDL first
 
@@ -250,7 +250,7 @@ func TestOnline(t *testing.T) {
 		ForceInplace: true,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInstantDDL) // not possible
 	assert.True(t, m.usedInplaceDDL)  // as
@@ -277,7 +277,7 @@ func TestOnline(t *testing.T) {
 		ForceInplace: false,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInstantDDL) // unfortunately false in 8.0, see https://bugs.mysql.com/bug.php?id=113355
 	assert.True(t, m.usedInplaceDDL)
@@ -304,7 +304,7 @@ func TestOnline(t *testing.T) {
 		ForceInplace: false,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInstantDDL) // unfortunately false in 8.0, see https://bugs.mysql.com/bug.php?id=113355
 	assert.False(t, m.usedInplaceDDL) // unfortunately false, since it combines INSTANT and INPLACE operations
@@ -331,7 +331,7 @@ func TestTableLength(t *testing.T) {
 		Alter:    "ENGINE=InnoDB",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "table name must be less than 54 characters")
 	assert.NoError(t, m.Close())
@@ -348,7 +348,7 @@ func TestTableLength(t *testing.T) {
 		Alter:    "ENGINE=InnoDB",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "table name must be less than 54 characters")
 	assert.NoError(t, m.Close())
@@ -432,7 +432,7 @@ func TestBadAlter(t *testing.T) {
 		Alter:    "RENAME COLUMN name TO name2, ADD INDEX(name)", // need both, otherwise INSTANT algorithm will do the rename
 	})
 	assert.NoError(t, err) // does not parse alter yet.
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err) // alter is invalid
 	assert.ErrorContains(t, err, "renames are not supported")
 	assert.NoError(t, m.Close())
@@ -449,7 +449,7 @@ func TestBadAlter(t *testing.T) {
 		Alter:    "CHANGE name name2 VARCHAR(255), ADD INDEX(name)", // need both, otherwise INSTANT algorithm will do the rename
 	})
 	assert.NoError(t, err) // does not parse alter yet.
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err) // alter is invalid
 	assert.ErrorContains(t, err, "renames are not supported")
 	assert.NoError(t, m.Close())
@@ -465,7 +465,7 @@ func TestBadAlter(t *testing.T) {
 		Alter:    "CHANGE name name VARCHAR(200), ADD INDEX(name)", //nolint: dupword
 	})
 	assert.NoError(t, err) // does not parse alter yet.
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err) // its valid, no rename
 	assert.NoError(t, m.Close())
 
@@ -482,7 +482,7 @@ func TestBadAlter(t *testing.T) {
 		Alter:    "DROP PRIMARY KEY",
 	})
 	assert.NoError(t, err) // does not parse alter yet.
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "dropping primary key")
 	assert.NoError(t, m.Close())
@@ -521,7 +521,7 @@ func TestChangeDatatypeLossyNoAutoInc(t *testing.T) {
 		Alter:    "CHANGE COLUMN id id INT NOT NULL auto_increment", //nolint: dupword
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Out of range value")    // Error 1264: Out of range value for column 'id' at row 1
 	assert.Less(t, m.copier.CopyChunksCount, uint64(500)) // should be very low
@@ -555,7 +555,7 @@ func TestChangeDatatypeLossless(t *testing.T) {
 		Checksum: false,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)                                // works because there are no violations.
 	assert.Less(t, m.copier.CopyChunksCount, uint64(500)) // prefetch makes it copy fast.
 	assert.NoError(t, m.Close())
@@ -590,7 +590,7 @@ func TestChangeDatatypeLossyFailEarly(t *testing.T) {
 		Alter:    "CHANGE COLUMN b b varchar(255) NOT NULL", //nolint: dupword
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err) // there is a violation where row 1 is NULL
 	assert.NoError(t, m.Close())
 }
@@ -629,7 +629,7 @@ func TestAddUniqueIndexChecksumEnabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.False(t, m.migration.Checksum)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)                 // not unique
 	assert.NoError(t, m.Close())         // need to close now otherwise we'll get an error on re-opening it.
 	assert.True(t, m.migration.Checksum) // it force enables a checksum
@@ -645,7 +645,7 @@ func TestAddUniqueIndexChecksumEnabled(t *testing.T) {
 		Alter:    "ADD UNIQUE INDEX b (b)",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err) // works fine.
 	assert.NoError(t, m.Close())
 }
@@ -673,7 +673,7 @@ func TestChangeNonIntPK(t *testing.T) {
 		Alter:    "CHANGE COLUMN b b VARCHAR(255) NOT NULL", //nolint: dupword
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, m.Close())
 }
@@ -741,10 +741,10 @@ func TestCheckpoint(t *testing.T) {
 
 		// Get Table Info
 		r.table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
-		err = r.table.SetInfo(context.TODO())
+		err = r.table.SetInfo(t.Context())
 		assert.NoError(t, err)
-		assert.NoError(t, r.dropOldTable(context.TODO()))
-		go r.dumpStatus(context.TODO()) // start periodically writing status
+		assert.NoError(t, r.dropOldTable(t.Context()))
+		go r.dumpStatus(t.Context()) // start periodically writing status
 		return r
 	}
 
@@ -753,12 +753,12 @@ func TestCheckpoint(t *testing.T) {
 	// Which first checks if the table can be restored from checkpoint.
 	// Because this is the first run, it can't.
 
-	assert.Error(t, r.resumeFromCheckpoint(context.TODO()))
+	assert.Error(t, r.resumeFromCheckpoint(t.Context()))
 
 	// So we proceed with the initial steps.
-	assert.NoError(t, r.createNewTable(context.TODO()))
-	assert.NoError(t, r.alterNewTable(context.TODO()))
-	assert.NoError(t, r.createCheckpointTable(context.TODO()))
+	assert.NoError(t, r.createNewTable(t.Context()))
+	assert.NoError(t, r.alterNewTable(t.Context()))
+	assert.NoError(t, r.createCheckpointTable(t.Context()))
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
 		Logger:          logrus.New(), // don't use the logger for migration since we feed status to it.
 		Concurrency:     4,
@@ -800,14 +800,14 @@ func TestCheckpoint(t *testing.T) {
 	_, err = r.copier.GetLowWatermark()
 	assert.Error(t, err)
 	// Dump checkpoint also returns an error for the same reason.
-	assert.Error(t, r.dumpCheckpoint(context.TODO()))
+	assert.Error(t, r.dumpCheckpoint(t.Context()))
 
 	// Because it's multi-threaded, we can't guarantee the order of the chunks.
 	// Let's complete them in the order of 2, 1, 3. When 2 phones home first
 	// it should be queued. Then when 1 phones home it should apply and de-queue 2.
-	assert.NoError(t, r.copier.CopyChunk(context.TODO(), chunk2))
-	assert.NoError(t, r.copier.CopyChunk(context.TODO(), chunk1))
-	assert.NoError(t, r.copier.CopyChunk(context.TODO(), chunk3))
+	assert.NoError(t, r.copier.CopyChunk(t.Context(), chunk2))
+	assert.NoError(t, r.copier.CopyChunk(t.Context(), chunk1))
+	assert.NoError(t, r.copier.CopyChunk(t.Context(), chunk3))
 
 	time.Sleep(time.Second) // wait for status to be updated.
 	testLogger.Lock()
@@ -820,7 +820,7 @@ func TestCheckpoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, "{\"Key\":[\"id\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"1001\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"2001\"],\"Inclusive\":false}}", watermark)
 	// Dump a checkpoint
-	assert.NoError(t, r.dumpCheckpoint(context.TODO()))
+	assert.NoError(t, r.dumpCheckpoint(t.Context()))
 
 	// Close everything, we can't use r.Close() because it will delete
 	// the checkpoint table.
@@ -832,7 +832,7 @@ func TestCheckpoint(t *testing.T) {
 	// from checkpoint again.
 
 	r = preSetup()
-	assert.NoError(t, r.resumeFromCheckpoint(context.TODO()))
+	assert.NoError(t, r.resumeFromCheckpoint(t.Context()))
 
 	// Start the binary log feed just before copy rows starts.
 	err = r.replClient.Run()
@@ -846,7 +846,7 @@ func TestCheckpoint(t *testing.T) {
 	chunk, err := r.copier.Next4Test()
 	assert.NoError(t, err)
 	assert.Equal(t, "1001", chunk.LowerBound.Value[0].String())
-	assert.NoError(t, r.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, r.copier.CopyChunk(t.Context(), chunk))
 
 	// It's ideally not typical but you can still dump checkpoint from
 	// a restored checkpoint state. We won't have advanced anywhere from
@@ -855,13 +855,13 @@ func TestCheckpoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, "{\"Key\":[\"id\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"1001\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"2001\"],\"Inclusive\":false}}", watermark)
 	// Dump a checkpoint
-	assert.NoError(t, r.dumpCheckpoint(context.TODO()))
+	assert.NoError(t, r.dumpCheckpoint(t.Context()))
 
 	// Let's confirm we do advance the watermark.
 	for range 10 {
 		chunk, err = r.copier.Next4Test()
 		assert.NoError(t, err)
-		assert.NoError(t, r.copier.CopyChunk(context.TODO(), chunk))
+		assert.NoError(t, r.copier.CopyChunk(t.Context(), chunk))
 	}
 
 	watermark, err = r.copier.GetLowWatermark()
@@ -898,14 +898,14 @@ func TestCheckpointRestore(t *testing.T) {
 	assert.NoError(t, err)
 	// Get Table Info
 	r.table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
-	err = r.table.SetInfo(context.TODO())
+	err = r.table.SetInfo(t.Context())
 	assert.NoError(t, err)
-	assert.NoError(t, r.dropOldTable(context.TODO()))
+	assert.NoError(t, r.dropOldTable(t.Context()))
 
 	// So we proceed with the initial steps.
-	assert.NoError(t, r.createNewTable(context.TODO()))
-	assert.NoError(t, r.alterNewTable(context.TODO()))
-	assert.NoError(t, r.createCheckpointTable(context.TODO()))
+	assert.NoError(t, r.createNewTable(t.Context()))
+	assert.NoError(t, r.alterNewTable(t.Context()))
+	assert.NoError(t, r.createCheckpointTable(t.Context()))
 
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.table, r.newTable, r.migration.Username, r.migration.Password, &repl.ClientConfig{
 		Logger:          logrus.New(),
@@ -921,7 +921,7 @@ func TestCheckpointRestore(t *testing.T) {
 	// from issue #125
 	watermark := "{\"Key\":[\"id\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\":[\"53926425\"],\"Inclusive\":true},\"UpperBound\":{\"Value\":[\"53926425\"],\"Inclusive\":false}}"
 	binlog := r.replClient.GetBinlogApplyPosition()
-	err = dbconn.Exec(context.TODO(), r.db, `INSERT INTO %n.%n
+	err = dbconn.Exec(t.Context(), r.db, `INSERT INTO %n.%n
 	(copier_watermark, checksum_watermark, binlog_name, binlog_pos, rows_copied, rows_copied_logical, alter_statement)
 	VALUES
 	(%?, %?, %?, %?, %?, %?, %?)`,
@@ -947,14 +947,14 @@ func TestCheckpointRestore(t *testing.T) {
 		Alter:    "ENGINE=InnoDB",
 	})
 	assert.NoError(t, err)
-	err = r2.Run(context.TODO())
+	err = r2.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, r2.usedResumeFromCheckpoint)
 }
 
 // https://github.com/cashapp/spirit/issues/381
 func TestCheckpointRestoreBinaryPK(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	tbl := `CREATE TABLE binarypk (
  main_id varbinary(16) NOT NULL,
  sub_id varchar(36) CHARACTER SET latin1 COLLATE latin1_swedish_ci GENERATED ALWAYS AS (jsonbody->>'$._id') STORED NOT NULL,
@@ -1016,7 +1016,7 @@ func TestCheckpointRestoreBinaryPK(t *testing.T) {
 		assert.NoError(t, r.copier.CopyChunk(ctx, chunk))
 	}
 	// Dump checkpoint
-	assert.NoError(t, r.dumpCheckpoint(context.TODO()))
+	assert.NoError(t, r.dumpCheckpoint(t.Context()))
 	assert.NoError(t, r.Close())
 
 	// Try and resume and then check if we used a checkpoint
@@ -1032,7 +1032,7 @@ func TestCheckpointRestoreBinaryPK(t *testing.T) {
 		Checksum: true,
 	})
 	assert.NoError(t, err)
-	err = r2.Run(context.TODO())
+	err = r2.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, r2.usedResumeFromCheckpoint) // managed to resume.
 }
@@ -1068,7 +1068,7 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 	// When we see that we are waiting on the sentinel table,
 	// we then manually start the first bits of checksum, and then close()
 	// We should be able to resume from the checkpoint into the checksum state.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		err := r.Run(ctx)
 		assert.Error(t, err) // context cancelled
@@ -1079,10 +1079,10 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	assert.NoError(t, r.checksum(context.TODO()))       // run the checksum, the original Run is blocked on sentinel.
-	assert.NoError(t, r.dumpCheckpoint(context.TODO())) // dump a checkpoint with the watermark.
-	cancel()                                            // unblock the original waiting on sentinel.
-	assert.NoError(t, r.Close())                        // close the run.
+	assert.NoError(t, r.checksum(t.Context()))       // run the checksum, the original Run is blocked on sentinel.
+	assert.NoError(t, r.dumpCheckpoint(t.Context())) // dump a checkpoint with the watermark.
+	cancel()                                         // unblock the original waiting on sentinel.
+	assert.NoError(t, r.Close())                     // close the run.
 
 	// drop the sentinel table.
 	testutils.RunSQL(t, `DROP TABLE _cptresume_sentinel`)
@@ -1104,7 +1104,7 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 		Checksum:        true,
 	})
 	assert.NoError(t, err)
-	err = r2.Run(context.Background())
+	err = r2.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, r2.usedResumeFromCheckpoint)
 	assert.NotEmpty(t, r2.checksumWatermark) // it had a checksum watermark
@@ -1144,9 +1144,9 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 		assert.NoError(t, err)
 		// Get Table Info
 		m.table = table.NewTableInfo(m.db, m.migration.Database, m.migration.Table)
-		err = m.table.SetInfo(context.TODO())
+		err = m.table.SetInfo(t.Context())
 		assert.NoError(t, err)
-		assert.NoError(t, m.dropOldTable(context.TODO()))
+		assert.NoError(t, m.dropOldTable(t.Context()))
 		return m
 	}
 
@@ -1155,12 +1155,12 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	// Which first checks if the table can be restored from checkpoint.
 	// Because this is the first run, it can't.
 
-	assert.Error(t, m.resumeFromCheckpoint(context.TODO()))
+	assert.Error(t, m.resumeFromCheckpoint(t.Context()))
 
 	// So we proceed with the initial steps.
-	assert.NoError(t, m.createNewTable(context.TODO()))
-	assert.NoError(t, m.alterNewTable(context.TODO()))
-	assert.NoError(t, m.createCheckpointTable(context.TODO()))
+	assert.NoError(t, m.createNewTable(t.Context()))
+	assert.NoError(t, m.alterNewTable(t.Context()))
+	assert.NoError(t, m.createCheckpointTable(t.Context()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
 		Logger:          logger,
@@ -1196,12 +1196,12 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	_, err = m.copier.GetLowWatermark()
 	assert.Error(t, err)
 	// Dump checkpoint also returns an error for the same reason.
-	assert.Error(t, m.dumpCheckpoint(context.TODO()))
+	assert.Error(t, m.dumpCheckpoint(t.Context()))
 
 	// Because it's multi-threaded, we can't guarantee the order of the chunks.
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk2))
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk1))
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk3))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk2))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk1))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk3))
 
 	// The watermark should exist now, because migrateChunk()
 	// gives feedback back to table.
@@ -1210,7 +1210,7 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, "{\"Key\":[\"id\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"1001\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"2001\"],\"Inclusive\":false}}", watermark)
 	// Dump a checkpoint
-	assert.NoError(t, m.dumpCheckpoint(context.TODO()))
+	assert.NoError(t, m.dumpCheckpoint(t.Context()))
 
 	// Close the db connection since m is to be destroyed.
 	assert.NoError(t, m.db.Close())
@@ -1219,7 +1219,7 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	// from checkpoint again.
 
 	m = preSetup("ADD COLUMN id4 INT NOT NULL DEFAULT 0, ADD INDEX(id2)")
-	assert.Error(t, m.resumeFromCheckpoint(context.TODO())) // it should error because the ALTER does not match.
+	assert.Error(t, m.resumeFromCheckpoint(t.Context())) // it should error because the ALTER does not match.
 }
 
 // TestE2EBinlogSubscribingCompositeKey and TestE2EBinlogSubscribingNonCompositeKey tests
@@ -1347,16 +1347,16 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	defer m.db.Close()
 	// Get Table Info
 	m.table = table.NewTableInfo(m.db, m.migration.Database, m.migration.Table)
-	err = m.table.SetInfo(context.TODO())
+	err = m.table.SetInfo(t.Context())
 	assert.NoError(t, err)
-	assert.NoError(t, m.dropOldTable(context.TODO()))
+	assert.NoError(t, m.dropOldTable(t.Context()))
 
 	// migration.Run usually calls m.Migrate() here.
 	// Which does the following before calling copyRows:
 	// So we proceed with the initial steps.
-	assert.NoError(t, m.createNewTable(context.TODO()))
-	assert.NoError(t, m.alterNewTable(context.TODO()))
-	assert.NoError(t, m.createCheckpointTable(context.TODO()))
+	assert.NoError(t, m.createNewTable(t.Context()))
+	assert.NoError(t, m.alterNewTable(t.Context()))
+	assert.NoError(t, m.createCheckpointTable(t.Context()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
 		Logger:          logger,
@@ -1393,7 +1393,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, chunk)
 	assert.Equal(t, "((`id1` < 1001)\n OR (`id1` = 1001 AND `id2` < 1))", chunk.String())
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 	assert.Equal(t, Progress{CurrentState: stateCopyRows.String(), Summary: "1000/1200 83.33% copyRows ETA TBD"}, m.GetProgress())
 
 	// Now insert some data.
@@ -1401,26 +1401,26 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 
 	// The composite chunker does not support keyAboveHighWatermark
 	// so it will show up as a delta.
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 
 	// Second chunk
 	chunk, err = m.copier.Next4Test()
 	assert.NoError(t, err)
 	assert.Equal(t, "((`id1` > 1001)\n OR (`id1` = 1001 AND `id2` >= 1))", chunk.String())
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 	assert.Equal(t, Progress{CurrentState: stateCopyRows.String(), Summary: "1201/1200 100.08% copyRows ETA DUE"}, m.GetProgress())
 
 	// Now insert some data.
 	// This should be picked up by the binlog subscription
 	// because it is within chunk size range of the second chunk.
 	testutils.RunSQL(t, `insert into e2et1 (id1, id2) values (5, 2)`)
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 2, m.replClient.GetDeltaLen())
 
 	testutils.RunSQL(t, `delete from e2et1 where id1 = 1`)
 	assert.False(t, m.copier.KeyAboveHighWatermark(1))
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 3, m.replClient.GetDeltaLen())
 
 	// Some data is inserted later, even though the last chunk is done.
@@ -1430,11 +1430,11 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 
 	// Now that copy rows is done, we flush the changeset until trivial.
 	// and perform the optional checksum.
-	assert.NoError(t, m.replClient.Flush(context.TODO()))
+	assert.NoError(t, m.replClient.Flush(t.Context()))
 	m.setCurrentState(stateApplyChangeset)
 	assert.Equal(t, "applyChangeset", m.getCurrentState().String())
 	m.setCurrentState(stateChecksum)
-	assert.NoError(t, m.checksum(context.TODO()))
+	assert.NoError(t, m.checksum(t.Context()))
 	assert.Equal(t, "postChecksum", m.getCurrentState().String())
 	assert.Equal(t, Progress{CurrentState: statePostChecksum.String(), Summary: "Applying Changeset Deltas=0"}, m.GetProgress())
 
@@ -1476,16 +1476,16 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	defer m.db.Close()
 	// Get Table Info
 	m.table = table.NewTableInfo(m.db, m.migration.Database, m.migration.Table)
-	err = m.table.SetInfo(context.TODO())
+	err = m.table.SetInfo(t.Context())
 	assert.NoError(t, err)
-	assert.NoError(t, m.dropOldTable(context.TODO()))
+	assert.NoError(t, m.dropOldTable(t.Context()))
 
 	// migration.Run usually calls m.Migrate() here.
 	// Which does the following before calling copyRows:
 	// So we proceed with the initial steps.
-	assert.NoError(t, m.createNewTable(context.TODO()))
-	assert.NoError(t, m.alterNewTable(context.TODO()))
-	assert.NoError(t, m.createCheckpointTable(context.TODO()))
+	assert.NoError(t, m.createNewTable(t.Context()))
+	assert.NoError(t, m.alterNewTable(t.Context()))
+	assert.NoError(t, m.createCheckpointTable(t.Context()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
 		Logger:          logger,
@@ -1523,7 +1523,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	chunk, err := m.copier.Next4Test()
 	assert.NoError(t, err)
 	assert.NotNil(t, chunk)
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 	assert.Equal(t, "`id` < 1", chunk.String())
 
 	// Now insert some data.
@@ -1534,13 +1534,13 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 
 	// Give it a chance, since we need to read from the binary log to populate this
 	// Even though we expect nothing.
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 0, m.replClient.GetDeltaLen())
 
 	// second chunk is between min and max value.
 	chunk, err = m.copier.Next4Test()
 	assert.NoError(t, err)
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 	assert.Equal(t, "`id` >= 1 AND `id` < 1001", chunk.String())
 
 	// Now insert some data.
@@ -1548,19 +1548,19 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// because it is within chunk size range of the second chunk.
 	testutils.RunSQL(t, `insert into e2et2 (id) values (5)`)
 	assert.False(t, m.copier.KeyAboveHighWatermark(5))
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 
 	testutils.RunSQL(t, `delete from e2et2 where id = 1`)
 	assert.False(t, m.copier.KeyAboveHighWatermark(1))
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 2, m.replClient.GetDeltaLen())
 
 	// third (and last) chunk is open ended,
 	// so anything after it will be picked up by the binlog.
 	chunk, err = m.copier.Next4Test()
 	assert.NoError(t, err)
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 	assert.Equal(t, "`id` >= 1001", chunk.String())
 
 	// Some data is inserted later, even though the last chunk is done.
@@ -1572,11 +1572,11 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 
 	// Now that copy rows is done, we flush the changeset until trivial.
 	// and perform the optional checksum.
-	assert.NoError(t, m.replClient.Flush(context.TODO()))
+	assert.NoError(t, m.replClient.Flush(t.Context()))
 	m.setCurrentState(stateApplyChangeset)
 	assert.Equal(t, "applyChangeset", m.getCurrentState().String())
 	m.setCurrentState(stateChecksum)
-	assert.NoError(t, m.checksum(context.TODO()))
+	assert.NoError(t, m.checksum(t.Context()))
 	assert.Equal(t, "postChecksum", m.getCurrentState().String())
 	// All done!
 }
@@ -1602,8 +1602,8 @@ func TestForRemainingTableArtifacts(t *testing.T) {
 		Table:    "remainingtbl",
 		Alter:    "ENGINE=InnoDB",
 	})
-	assert.NoError(t, err)                         // everything is specified.
-	assert.NoError(t, m.Run(context.Background())) // it's an accepted type.
+	assert.NoError(t, err)                // everything is specified.
+	assert.NoError(t, m.Run(t.Context())) // it's an accepted type.
 	assert.NoError(t, m.Close())
 
 	// Now we should have a _remainingtbl_old table and a remainingtbl table
@@ -1642,7 +1642,7 @@ func TestDropColumn(t *testing.T) {
 		Alter:    "DROP COLUMN b, ENGINE=InnoDB", // need both to ensure it is not instant!
 	})
 	assert.NoError(t, err)
-	assert.NoError(t, m.Run(context.Background()))
+	assert.NoError(t, m.Run(t.Context()))
 
 	assert.False(t, m.usedInstantDDL) // need to ensure it uses full process.
 	assert.NoError(t, m.Close())
@@ -1685,7 +1685,7 @@ func TestNullToNotNull(t *testing.T) {
 		Alter:    "modify column created_at datetime(3) not null default current_timestamp(3)",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Column 'created_at' cannot be null")
 	assert.NoError(t, m.Close())
@@ -1732,7 +1732,7 @@ func TestChunkerPrefetching(t *testing.T) {
 		Alter:    "engine=innodb",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, m.Close())
 }
@@ -1782,7 +1782,7 @@ func TestTpConversion(t *testing.T) {
 		`,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, m.Close())
 }
@@ -1821,7 +1821,7 @@ func TestResumeFromCheckpointE2E(t *testing.T) {
 	runner, err := NewRunner(migration)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	go func() {
 		err := runner.Run(ctx)
@@ -1865,7 +1865,7 @@ func TestResumeFromCheckpointE2E(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, m.usedResumeFromCheckpoint)
 	assert.NoError(t, m.Close())
@@ -1915,7 +1915,7 @@ FROM compositevarcharpk a WHERE version='1'`)
 	}
 	runner, err := NewRunner(migration)
 	assert.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		err := runner.Run(ctx)
 		assert.Error(t, err) // it gets interrupted as soon as there is a checkpoint saved.
@@ -1954,7 +1954,7 @@ FROM compositevarcharpk a WHERE version='1'`)
 	assert.NoError(t, err)
 	assert.NotNil(t, m2)
 
-	err = m2.Run(context.Background())
+	err = m2.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, m2.usedResumeFromCheckpoint)
 	assert.NoError(t, m2.Close())
@@ -1996,7 +1996,7 @@ func TestResumeFromCheckpointStrict(t *testing.T) {
 
 	// Kick off a migration with --strict enabled and let it run until the first checkpoint is available
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	runner, err := NewRunner(migration)
 	assert.NoError(t, err)
@@ -2046,7 +2046,7 @@ func TestResumeFromCheckpointStrict(t *testing.T) {
 	runner, err = NewRunner(migrationB)
 	assert.NoError(t, err)
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrMismatchedAlter)
 
@@ -2061,7 +2061,7 @@ func TestResumeFromCheckpointStrict(t *testing.T) {
 	runner, err = NewRunner(migrationB)
 	assert.NoError(t, err)
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, runner.usedResumeFromCheckpoint)
 
@@ -2187,15 +2187,15 @@ func TestE2ERogueValues(t *testing.T) {
 	defer m.db.Close()
 	// Get Table Info
 	m.table = table.NewTableInfo(m.db, m.migration.Database, m.migration.Table)
-	err = m.table.SetInfo(context.TODO())
+	err = m.table.SetInfo(t.Context())
 	assert.NoError(t, err)
-	assert.NoError(t, m.dropOldTable(context.TODO()))
+	assert.NoError(t, m.dropOldTable(t.Context()))
 
 	// runner.Run usually does the following before calling copyRows:
 	// So we proceed with the initial steps.
-	assert.NoError(t, m.createNewTable(context.TODO()))
-	assert.NoError(t, m.alterNewTable(context.TODO()))
-	assert.NoError(t, m.createCheckpointTable(context.TODO()))
+	assert.NoError(t, m.createNewTable(t.Context()))
+	assert.NoError(t, m.alterNewTable(t.Context()))
+	assert.NoError(t, m.createCheckpointTable(t.Context()))
 	logger := logrus.New()
 	m.replClient = repl.NewClient(m.db, m.migration.Host, m.table, m.newTable, m.migration.Username, m.migration.Password, &repl.ClientConfig{
 		Logger:          logger,
@@ -2232,7 +2232,7 @@ func TestE2ERogueValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, chunk)
 	assert.Contains(t, chunk.String(), ` < "819 \". "`)
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 
 	// Now insert some data, for binary type it will always say its
 	// below the watermark.
@@ -2243,26 +2243,26 @@ func TestE2ERogueValues(t *testing.T) {
 	chunk, err = m.copier.Next4Test()
 	assert.NoError(t, err)
 	assert.Equal(t, "((`datetime` > \"819 \\\". \")\n OR (`datetime` = \"819 \\\". \" AND `col2` >= 1))", chunk.String())
-	assert.NoError(t, m.copier.CopyChunk(context.TODO(), chunk))
+	assert.NoError(t, m.copier.CopyChunk(t.Context(), chunk))
 
 	// Now insert some data.
 	// This should be picked up by the binlog subscription
 	testutils.RunSQL(t, `insert into e2erogue values (5, 2)`)
 	assert.False(t, m.copier.KeyAboveHighWatermark(5))
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 2, m.replClient.GetDeltaLen())
 
 	testutils.RunSQL(t, "delete from e2erogue where `datetime` like '819%'")
-	assert.NoError(t, m.replClient.BlockWait(context.Background()))
+	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 3, m.replClient.GetDeltaLen())
 
 	// Now that copy rows is done, we flush the changeset until trivial.
 	// and perform the optional checksum.
-	assert.NoError(t, m.replClient.Flush(context.TODO()))
+	assert.NoError(t, m.replClient.Flush(t.Context()))
 	m.setCurrentState(stateApplyChangeset)
 	assert.Equal(t, "applyChangeset", m.getCurrentState().String())
 	m.setCurrentState(stateChecksum)
-	assert.NoError(t, m.checksum(context.TODO()))
+	assert.NoError(t, m.checksum(t.Context()))
 	assert.Equal(t, "postChecksum", m.getCurrentState().String())
 	// All done!
 }
@@ -2305,8 +2305,8 @@ func TestPartitionedTable(t *testing.T) {
 		Table:    "part1",
 		Alter:    "ENGINE=InnoDB",
 	})
-	assert.NoError(t, err)                         // everything is specified.
-	assert.NoError(t, m.Run(context.Background())) // should work.
+	assert.NoError(t, err)                // everything is specified.
+	assert.NoError(t, m.Run(t.Context())) // should work.
 	assert.NoError(t, m.Close())
 }
 
@@ -2349,7 +2349,7 @@ func TestResumeFromCheckpointPhantom(t *testing.T) {
 		TargetChunkTime: 100 * time.Millisecond,
 	})
 	assert.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Do the initial setup.
 	m.db, err = dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
@@ -2429,7 +2429,7 @@ func TestResumeFromCheckpointPhantom(t *testing.T) {
 
 	// Resume the migration using and apply all of the replication
 	// changes before starting the copier.
-	ctx = context.Background()
+	ctx = t.Context()
 	m, err = NewRunner(&Migration{
 		Host:            cfg.Addr,
 		Username:        cfg.User,
@@ -2495,7 +2495,7 @@ func TestVarcharE2E(t *testing.T) {
 		Alter:    "ENGINE=InnoDB",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, m.Close())
 }
@@ -2524,7 +2524,7 @@ func TestSkipDropAfterCutover(t *testing.T) {
 		SkipDropAfterCutover: true,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 
 	sql := fmt.Sprintf(
@@ -2563,7 +2563,7 @@ func TestDropAfterCutover(t *testing.T) {
 		SkipDropAfterCutover: false,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 
 	sql := fmt.Sprintf(
@@ -2613,7 +2613,7 @@ func TestDeferCutOver(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = m.Run(context.Background())
+		err = m.Run(t.Context())
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
 	}()
@@ -2666,7 +2666,7 @@ func TestDeferCutOverE2E(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	go func() {
-		err := m.Run(context.Background())
+		err := m.Run(t.Context())
 		assert.NoError(t, err)
 		c <- err
 	}()
@@ -2740,7 +2740,7 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	go func() {
-		err := m.Run(context.Background())
+		err := m.Run(t.Context())
 		assert.NoError(t, err)
 		c <- err
 	}()
@@ -2758,7 +2758,7 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 	for range 4 {
 		testutils.RunSQL(t, fmt.Sprintf("insert into %s (id) select null from %s a, %s b, %s c limit 1000", tableName, tableName, tableName, tableName))
 		time.Sleep(1 * time.Second)
-		m.replClient.Flush(context.Background())
+		m.replClient.Flush(t.Context())
 		newBinlogPos := m.replClient.GetBinlogApplyPosition()
 		assert.Equal(t, 1, newBinlogPos.Compare(binlogPos))
 		binlogPos = newBinlogPos
@@ -2825,7 +2825,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	runner, err := NewRunner(migration)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	go func() {
 		err := runner.Run(ctx)
@@ -2882,7 +2882,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
 	assert.True(t, m.usedResumeFromCheckpoint)
@@ -2909,7 +2909,7 @@ func TestPreRunChecksE2E(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 	defer db.Close()
-	err = m.runChecks(context.TODO(), check.ScopePreRun)
+	err = m.runChecks(t.Context(), check.ScopePreRun)
 	assert.NoError(t, err)
 }
 
@@ -2965,7 +2965,7 @@ func TestForNonInstantBurn(t *testing.T) {
 		Alter:    "add newcol2 int",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 
 	assert.False(t, m.usedInstantDDL) // it would have had to apply a copy.
@@ -3006,7 +3006,7 @@ func TestIndexVisibility(t *testing.T) {
 		Alter:    "ALTER INDEX b INVISIBLE",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 
 	assert.True(t, m.usedInplaceDDL) // expected to count as safe.
@@ -3023,7 +3023,7 @@ func TestIndexVisibility(t *testing.T) {
 		Alter:    "ALTER INDEX b VISIBLE",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.True(t, m.usedInplaceDDL) // expected to count as safe.
 	assert.NoError(t, m.Close())
@@ -3040,7 +3040,7 @@ func TestIndexVisibility(t *testing.T) {
 		Alter:    "ALTER INDEX b VISIBLE, ADD INDEX (c)",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.NoError(t, m.Close()) // it's errored, we don't need to try again. We can close.
 
@@ -3056,7 +3056,7 @@ func TestIndexVisibility(t *testing.T) {
 		ForceInplace: true,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, m.Close())
 
@@ -3074,7 +3074,7 @@ func TestIndexVisibility(t *testing.T) {
 		ForceInplace: true,
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.Error(t, err)
 	assert.NoError(t, m.Close()) // it's errored, we don't need to try again. We can close.
 }
@@ -3115,7 +3115,7 @@ func TestPreventConcurrentRuns(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = m.Run(context.Background())
+		err = m.Run(t.Context())
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
 	}()
@@ -3134,7 +3134,7 @@ func TestPreventConcurrentRuns(t *testing.T) {
 		DeferCutOver:         false,
 	})
 	assert.NoError(t, err)
-	err = m2.Run(context.Background())
+	err = m2.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "could not acquire metadata lock")
 }
@@ -3161,7 +3161,7 @@ func TestStatementWorkflowStillInstant(t *testing.T) {
 		Statement: "ALTER TABLE stmtworkflow ADD newcol INT",
 	})
 	assert.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	assert.NoError(t, err)
 
 	assert.True(t, m.usedInstantDDL) // expected to count as instant.

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -693,11 +693,13 @@ func (l *testLogger) Infof(format string, args ...interface{}) {
 	defer l.Unlock()
 	l.lastInfof = fmt.Sprintf(format, args...)
 }
+
 func (l *testLogger) Warnf(format string, args ...interface{}) {
 	l.Lock()
 	defer l.Unlock()
 	l.lastWarnf = fmt.Sprintf(format, args...)
 }
+
 func (l *testLogger) Debugf(format string, args ...interface{}) {
 	l.Lock()
 	defer l.Unlock()
@@ -775,7 +777,7 @@ func TestCheckpoint(t *testing.T) {
 	// Instead of calling r.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//r.copier.StartTime = time.Now()
+	// r.copier.StartTime = time.Now()
 	r.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", r.getCurrentState().String())
 
@@ -1178,7 +1180,7 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//m.copier.StartTime = time.Now()
+	// m.copier.StartTime = time.Now()
 	m.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", m.getCurrentState().String())
 
@@ -1383,7 +1385,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//m.copier.StartTime = time.Now()
+	// m.copier.StartTime = time.Now()
 	m.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", m.getCurrentState().String())
 
@@ -1513,7 +1515,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//m.copier.StartTime = time.Now()
+	// m.copier.StartTime = time.Now()
 	m.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", m.getCurrentState().String())
 
@@ -2222,7 +2224,7 @@ func TestE2ERogueValues(t *testing.T) {
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//m.copier.StartTime = time.Now()
+	// m.copier.StartTime = time.Now()
 	m.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", m.getCurrentState().String())
 
@@ -2386,7 +2388,7 @@ func TestResumeFromCheckpointPhantom(t *testing.T) {
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
 
-	//m.copier.StartTime = time.Now()
+	// m.copier.StartTime = time.Now()
 	m.setCurrentState(stateCopyRows)
 	assert.Equal(t, "copyRows", m.getCurrentState().String())
 
@@ -2752,7 +2754,6 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 	assert.NoError(t, err)
 	defer db.Close()
 	for m.getCurrentState() != stateWaitingOnSentinelTable {
-
 	}
 	assert.NoError(t, err)
 
@@ -3139,6 +3140,7 @@ func TestPreventConcurrentRuns(t *testing.T) {
 	err = m2.Run(t.Context())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "could not acquire metadata lock")
+	wg.Wait()
 }
 
 func TestStatementWorkflowStillInstant(t *testing.T) {
@@ -3224,7 +3226,7 @@ func TestTrailingSemicolon(t *testing.T) {
 		Password: cfg.Passwd,
 		Database: cfg.DBName,
 		Table:    "multiSecondary",
-		//https://github.com/cashapp/spirit/issues/384
+		// https://github.com/cashapp/spirit/issues/384
 		Alter:   dropIndexesAlter + "; ",
 		Threads: 1,
 	})

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -3118,7 +3118,8 @@ func TestPreventConcurrentRuns(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = m.Run(t.Context())
+		// Shadow err to avoid a data race
+		err := m.Run(t.Context())
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
 	}()

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -1073,11 +1073,9 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 		err := r.Run(ctx)
 		assert.Error(t, err) // context cancelled
 	}()
-	for {
+	for r.getCurrentState() < stateWaitingOnSentinelTable {
 		// Wait for the sentinel table.
-		if r.getCurrentState() >= stateWaitingOnSentinelTable {
-			break
-		}
+
 		time.Sleep(time.Millisecond)
 	}
 
@@ -2751,10 +2749,8 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
 	defer db.Close()
-	for {
-		if m.getCurrentState() == stateWaitingOnSentinelTable {
-			break
-		}
+	for m.getCurrentState() != stateWaitingOnSentinelTable {
+
 	}
 	assert.NoError(t, err)
 

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -3196,7 +3196,7 @@ func TestTrailingSemicolon(t *testing.T) {
 		Threads:  1,
 	})
 	require.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	require.NoError(t, err)
 
 	assert.True(t, m.usedInplaceDDL) // must be inplace
@@ -3212,7 +3212,7 @@ func TestTrailingSemicolon(t *testing.T) {
 		Threads:      1,
 	})
 	require.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	require.NoError(t, err)
 
 	require.True(t, m.usedInplaceDDL) // must be inplace
@@ -3229,7 +3229,7 @@ func TestTrailingSemicolon(t *testing.T) {
 		Threads: 1,
 	})
 	require.NoError(t, err)
-	err = m.Run(context.Background())
+	err = m.Run(t.Context())
 	require.NoError(t, err)
 
 	require.True(t, m.usedInplaceDDL) // must be inplace

--- a/pkg/row/copier_eta_history_test.go
+++ b/pkg/row/copier_eta_history_test.go
@@ -14,7 +14,7 @@ func TestCopierETAHistory(t *testing.T) {
 	// Add an ETA
 	history.addCurrentEstimateAndCompare(1 * time.Hour)
 	assert.Len(t, history.etaHistory, 1)
-	assert.Equal(t, "", history.getComparison())
+	assert.Empty(t, history.getComparison())
 
 	// Add another ETA and confirm it is NOT stored because it is too recent
 	history.addCurrentEstimateAndCompare(55 * time.Minute)

--- a/pkg/row/copier_test.go
+++ b/pkg/row/copier_test.go
@@ -40,16 +40,16 @@ func TestCopier(t *testing.T) {
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "copiert1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "copiert2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	copierConfig := NewCopierDefaultConfig()
 	testMetricsSink := &TestMetricsSink{}
 	copierConfig.MetricsSink = testMetricsSink
 	copier, err := NewCopier(db, t1, t2, copierConfig)
 	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(context.Background())) // works
+	assert.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t2 has one row.
 	var count int
@@ -73,14 +73,14 @@ func TestThrottler(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "throttlert1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "throttlert2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
 	copier.SetThrottler(&throttler.Noop{})
-	assert.NoError(t, copier.Run(context.Background())) // works
+	assert.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t2 has one row.
 	var count int
@@ -100,28 +100,28 @@ func TestCopierUniqueDestination(t *testing.T) {
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "copieruniqt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "copieruniqt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// if the checksum is FALSE, the unique violation will cause an error.
 	cfg := NewCopierDefaultConfig()
 	cfg.FinalChecksum = false
 	copier, err := NewCopier(db, t1, t2, cfg)
 	assert.NoError(t, err)
-	assert.Error(t, copier.Run(context.Background())) // fails
+	assert.Error(t, copier.Run(t.Context())) // fails
 
 	// however, if the checksum is TRUE, the unique violation will be ignored.
 	// This is because it's not possible to differentiate between a resume from checkpoint
 	// causing a duplicate key, and the DDL being applied causing it.
 	t1 = table.NewTableInfo(db, "test", "copieruniqt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 = table.NewTableInfo(db, "test", "copieruniqt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	copier, err = NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(context.Background())) // works
-	require.Equal(t, 0, db.Stats().InUse)               // no connections in use.
+	assert.NoError(t, copier.Run(t.Context())) // works
+	require.Equal(t, 0, db.Stats().InUse)      // no connections in use.
 }
 
 func TestCopierLossyDataTypeConversion(t *testing.T) {
@@ -135,14 +135,14 @@ func TestCopierLossyDataTypeConversion(t *testing.T) {
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "datatpt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "datatpt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.Contains(t, err.Error(), "unsafe warning")
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
@@ -158,14 +158,14 @@ func TestCopierNullToNotNullConversion(t *testing.T) {
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "null2notnullt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "null2notnullt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.Contains(t, err.Error(), "unsafe warning")
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
@@ -180,14 +180,14 @@ func TestSQLModeAllowZeroInvalidDates(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "invaliddt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "invaliddt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.NoError(t, err)
 	// Verify that t2 has one row.
 	var count int
@@ -206,9 +206,9 @@ func TestLockWaitTimeoutIsRetyable(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "lockt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "lockt2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Lock table t2 for 2 seconds.
 	// This should be enough to retry, but it will eventually be successful.
@@ -223,7 +223,7 @@ func TestLockWaitTimeoutIsRetyable(t *testing.T) {
 	}()
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.NoError(t, err) // succeeded within retry.
 }
 
@@ -245,9 +245,9 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 	require.Equal(t, 0, db.Stats().InUse)
 
 	t1 := table.NewTableInfo(db, "test", "lock2t1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "lock2t2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Lock again but for 60 seconds.
 	// This will cause a failure because the retry is less than this (2 retries * 1 sec + backoff)
@@ -267,7 +267,7 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 	wg.Wait() // Wait only for the lock to be acquired.
 	copier, err := NewCopier(db, t1, t2, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.Error(t, err) // exceeded retry.
 }
 
@@ -295,13 +295,13 @@ func TestETA(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "testeta1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "testeta2")
-	assert.NoError(t, t2.SetInfo(context.TODO()))
+	assert.NoError(t, t2.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, "test", "_testeta1_new")
-	assert.NoError(t, t1new.SetInfo(context.TODO()))
+	assert.NoError(t, t1new.SetInfo(t.Context()))
 	t2new := table.NewTableInfo(db, "test", "_testeta2_new")
-	assert.NoError(t, t2new.SetInfo(context.TODO()))
+	assert.NoError(t, t2new.SetInfo(t.Context()))
 
 	t1.EstimatedRows = 1000
 	t2.EstimatedRows = 1000
@@ -357,14 +357,14 @@ func TestCopierFromCheckpoint(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "copierchkpt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, "test", "_copierchkpt1_new")
-	assert.NoError(t, t1new.SetInfo(context.TODO()))
+	assert.NoError(t, t1new.SetInfo(t.Context()))
 
 	lowWatermark := `{"Key":["a"],"ChunkSize":1,"LowerBound":{"Value":["3"],"Inclusive":true},"UpperBound":{"Value":["4"],"Inclusive":false}}`
 	copier, err := NewCopierFromCheckpoint(db, t1, t1new, NewCopierDefaultConfig(), lowWatermark, 3, 3)
 	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(context.Background())) // works
+	assert.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t1new has 10 rows
 	var count int
@@ -391,13 +391,13 @@ func TestRangeOptimizationMustApply(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := table.NewTableInfo(db, "test", "rangeoptimizertest")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, "test", "_rangeoptimizertest_new")
-	assert.NoError(t, t1new.SetInfo(context.TODO()))
+	assert.NoError(t, t1new.SetInfo(t.Context()))
 
 	copier, err := NewCopier(db, t1, t1new, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.ErrorContains(t, err, "range_optimizer_max_mem_size") // verify that spirit refuses to run if it encounters range optimizer memory limits.
 
 	// Now create a new DB config, which should default to be unlimited.
@@ -407,6 +407,6 @@ func TestRangeOptimizationMustApply(t *testing.T) {
 	testutils.RunSQL(t, "TRUNCATE _rangeoptimizertest_new")
 	copier, err = NewCopier(db, t1, t1new, NewCopierDefaultConfig())
 	assert.NoError(t, err)
-	err = copier.Run(context.Background())
+	err = copier.Run(t.Context())
 	assert.NoError(t, err) // works now.
 }

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -33,7 +32,7 @@ func TestCompositeChunkerCompositeBinary(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "composite_binary_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	// Assert that the types are correct.
 	assert.Equal(t, []string{"varbinary", "varbinary"}, t1.keyColumnsMySQLTp)
@@ -134,7 +133,7 @@ func TestCompositeChunkerBinary(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "composite_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	// Assert that the types are correct.
 	assert.Equal(t, []string{"varbinary"}, t1.keyColumnsMySQLTp)
@@ -210,7 +209,7 @@ func TestCompositeChunkerInt(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "compositeint_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	// Assert that the types are correct.
 	assert.Equal(t, []string{"int"}, t1.keyColumnsMySQLTp)
@@ -269,7 +268,7 @@ func TestCompositeLowWatermark(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "compositewatermark_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	chunker := &chunkerComposite{
 		Ti:                     t1,
@@ -388,7 +387,7 @@ func TestCompositeSmallTable(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "compositesmall_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	chunker, err := NewChunker(t1, ChunkerDefaultTarget, logrus.New())
 	assert.NoError(t, err)
@@ -429,7 +428,7 @@ func TestSetKey(t *testing.T) {
 
 	// Test SetKey with PrimaryKey
 	t1 := NewTableInfo(db, "test", "setkey_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	chunkerPK := &chunkerComposite{
 		Ti:            t1,
 		ChunkerTarget: 100 * time.Millisecond,
@@ -560,7 +559,7 @@ func TestSetKeyCompositeKeyMerge(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "setkeycomposite_t1")
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	chunker := &chunkerComposite{
 		Ti:            t1,
 		ChunkerTarget: 100 * time.Millisecond,

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -294,7 +293,7 @@ func TestOptimisticPrefetchChunking(t *testing.T) {
 
 	t1 := newTableInfo4Test("test", "tprefetch")
 	t1.db = db
-	assert.NoError(t, t1.SetInfo(context.Background()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 	chunker := &chunkerOptimistic{
 		Ti:            t1,
 		ChunkerTarget: time.Second,

--- a/pkg/table/chunker_test.go
+++ b/pkg/table/chunker_test.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestCompositeChunker(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "composite")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	chunker, err := NewChunker(t1, 0, logrus.New())
 	assert.NoError(t, err)
@@ -45,7 +44,7 @@ func TestOptimisticChunker(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "optimistic")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	chunker, err := NewChunker(t1, 0, logrus.New())
 	assert.NoError(t, err)
@@ -67,7 +66,7 @@ func TestNewCompositeChunker(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "composite")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	chunker, err := NewCompositeChunker(t1, 0, logrus.New(), "age_idx", "age > 50")
 	assert.NoError(t, err)

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -40,7 +40,8 @@ func mySQLTypeToDatumTp(mysqlTp string) datumTp {
 
 func newDatum(val interface{}, tp datumTp) Datum {
 	var err error
-	if tp == signedType {
+	switch tp { //nolint:exhaustive
+	case signedType:
 		// We expect the value to be an int64, but it could be an int.
 		// Anything else we attempt to convert it
 		switch v := val.(type) {
@@ -54,7 +55,7 @@ func newDatum(val interface{}, tp datumTp) Datum {
 				panic("could not convert datum to int64")
 			}
 		}
-	} else if tp == unsignedType {
+	case unsignedType:
 		// We expect uint64, but it could be uint.
 		// We convert anything else.
 		switch v := val.(type) {
@@ -76,13 +77,14 @@ func newDatum(val interface{}, tp datumTp) Datum {
 }
 
 func datumValFromString(val string, tp datumTp) (interface{}, error) {
-	if tp == signedType {
+	switch tp { //nolint:exhaustive
+	case signedType:
 		i, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, err
 		}
 		return i, nil
-	} else if tp == unsignedType {
+	case unsignedType:
 		return strconv.ParseUint(val, 10, 64)
 	}
 	// If it starts with 0x then it's a binary string. If it was actually

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -78,7 +77,7 @@ func TestDiscovery(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "discoveryt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	assert.Equal(t, "discoveryt1", t1.TableName)
 	assert.Equal(t, "test", t1.SchemaName)
@@ -113,7 +112,7 @@ func TestDiscoveryUInt(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "discoveryuintt1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	assert.Equal(t, "discoveryuintt1", t1.TableName)
 	assert.Equal(t, "test", t1.SchemaName)
@@ -142,10 +141,10 @@ func TestDiscoveryNoKeyColumnsOrNoTable(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "discoverynokeyst1")
-	assert.ErrorContains(t, t1.SetInfo(context.TODO()), "no primary key found")
+	assert.ErrorContains(t, t1.SetInfo(t.Context()), "no primary key found")
 
 	t2 := NewTableInfo(db, "test", "t2fdsfds")
-	assert.ErrorContains(t, t2.SetInfo(context.TODO()), "table test.t2fdsfds does not exist")
+	assert.ErrorContains(t, t2.SetInfo(t.Context()), "table test.t2fdsfds does not exist")
 }
 
 func TestDiscoveryBalancesTable(t *testing.T) {
@@ -176,7 +175,7 @@ func TestDiscoveryBalancesTable(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "balances")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	assert.True(t, t1.KeyIsAutoInc)
 	assert.Equal(t, []string{"bigint"}, t1.keyColumnsMySQLTp)
@@ -207,7 +206,7 @@ func TestDiscoveryCompositeNonComparable(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "compnoncomparable")
-	assert.NoError(t, t1.SetInfo(context.TODO()))      // still discovers the primary key
+	assert.NoError(t, t1.SetInfo(t.Context()))         // still discovers the primary key
 	assert.Error(t, t1.PrimaryKeyIsMemoryComparable()) // but its non comparable
 }
 
@@ -226,7 +225,7 @@ func TestDiscoveryCompositeComparable(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "compcomparable")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	assert.True(t, t1.KeyIsAutoInc)
 	assert.Equal(t, []string{"int unsigned", "int"}, t1.keyColumnsMySQLTp)
@@ -262,7 +261,7 @@ func TestStatisticsUpdate(t *testing.T) {
 	}
 	t1.statisticsLastUpdated = time.Now()
 
-	go t1.AutoUpdateStatistics(context.Background(), time.Millisecond*10, logrus.New())
+	go t1.AutoUpdateStatistics(t.Context(), time.Millisecond*10, logrus.New())
 	time.Sleep(time.Millisecond * 100)
 
 	t1.Close()
@@ -284,7 +283,7 @@ func TestKeyColumnsValuesExtraction(t *testing.T) {
 	testutils.RunSQL(t, `insert into colvaluest1 values (1, 'a', 15), (2, 'b', 20), (3, 'c', 25)`)
 
 	t1 := NewTableInfo(db, "test", "colvaluest1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	var id, age int
 	var name string
@@ -318,7 +317,7 @@ func TestDiscoveryGeneratedCols(t *testing.T) {
 	defer db.Close()
 
 	t1 := NewTableInfo(db, "test", "generatedcolst1")
-	assert.NoError(t, t1.SetInfo(context.TODO()))
+	assert.NoError(t, t1.SetInfo(t.Context()))
 
 	// Can't check estimated rows (depends on MySQL version etc)
 	assert.Equal(t, []string{"id", "name", "b", "c1", "c2", "c3", "d"}, t1.Columns)

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -75,7 +75,7 @@ func removeEnumSetOpts(s string) string {
 }
 
 func removeZerofill(s string) string {
-	return strings.Replace(s, " zerofill", "", -1)
+	return strings.ReplaceAll(s, " zerofill", "")
 }
 
 func QuoteColumns(cols []string) string {


### PR DESCRIPTION
My local version of golangci-lint was somehow updated to v2.0.2 and it threw all kinds of a fit about the .golangci.yaml file. So I ran the migration tool and fixed up a bunch of the errors it surfaced.