### PR TITLE
Add test leak detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/siddontang/loggers v1.0.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/goleak v1.2.1
 	golang.org/x/sync v0.4.0
 )
 

--- a/pkg/check/privileges.go
+++ b/pkg/check/privileges.go
@@ -20,7 +20,7 @@ func privilegesCheck(ctx context.Context, r Resources, logger loggers.Advanced) 
 	// This is a re-implementation of the gh-ost check
 	// validateGrants() in gh-ost/go/logic/inspect.go
 	var foundAll, foundSuper, foundReplicationClient, foundReplicationSlave, foundDBAll, foundReload bool
-	rows, err := r.DB.QueryContext(ctx, `SHOW GRANTS`) //nolint: execinquery
+	rows, err := r.DB.QueryContext(ctx, `SHOW GRANTS`)
 	if err != nil {
 		return err
 	}

--- a/pkg/check/replicahealth.go
+++ b/pkg/check/replicahealth.go
@@ -18,7 +18,7 @@ func replicaHealth(ctx context.Context, r Resources, logger loggers.Advanced) er
 	if r.Replica == nil {
 		return nil // The user is not using the replica DSN feature.
 	}
-	rows, err := r.Replica.Query("SHOW REPLICA STATUS") //nolint: execinquery
+	rows, err := r.Replica.Query("SHOW REPLICA STATUS")
 	if err != nil {
 		return err
 	}

--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -4,16 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cashapp/spirit/pkg/testutils"
-
-	mysql "github.com/go-sql-driver/mysql"
-	"github.com/sirupsen/logrus"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/cashapp/spirit/pkg/dbconn"
 	"github.com/cashapp/spirit/pkg/repl"
 	"github.com/cashapp/spirit/pkg/table"
+	"github.com/cashapp/spirit/pkg/testutils"
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasicChecksum(t *testing.T) {

--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -1,6 +1,7 @@
 package checksum
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -11,7 +12,13 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+	os.Exit(m.Run())
+}
 
 func TestBasicChecksum(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS basic_checksum, _basic_checksum_new, _basic_checksum_chkpnt")
@@ -23,6 +30,7 @@ func TestBasicChecksum(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "basic_checksum")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -38,6 +46,7 @@ func TestBasicChecksum(t *testing.T) {
 		TargetBatchTime: time.Second,
 	})
 	assert.NoError(t, feed.Run())
+	defer feed.Close()
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
@@ -58,6 +67,7 @@ func TestBasicValidation(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "basic_validation")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -72,6 +82,7 @@ func TestBasicValidation(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	_, err = NewChecker(db, nil, t2, feed, NewCheckerDefaultConfig())
@@ -95,6 +106,7 @@ func TestFixCorrupt(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "fixcorruption_t1")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -109,6 +121,7 @@ func TestFixCorrupt(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	config := NewCheckerDefaultConfig()
@@ -138,6 +151,7 @@ func TestCorruptChecksum(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "chkpcorruptt1")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -152,6 +166,7 @@ func TestCorruptChecksum(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
@@ -170,6 +185,7 @@ func TestBoundaryCases(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "checkert1")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -184,6 +200,7 @@ func TestBoundaryCases(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
@@ -234,6 +251,7 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "tdatetime")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -248,6 +266,7 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	checker, err := NewChecker(db, t1, t2, feed, NewCheckerDefaultConfig())
@@ -265,6 +284,7 @@ func TestFromWatermark(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "tfromwatermark")
 	assert.NoError(t, t1.SetInfo(t.Context()))
@@ -279,6 +299,7 @@ func TestFromWatermark(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	assert.NoError(t, feed.Run())
 
 	config := NewCheckerDefaultConfig()

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -86,6 +86,7 @@ func NewMetadataLock(ctx context.Context, dsn string, table *table.TableInfo, lo
 	// We only Infof the initial acquisition.
 	logger.Infof("attempting to acquire metadata lock %s", mdl.lockName)
 	if err = getLock(); err != nil {
+		mdl.db.Close() // close if we are not returning an MDL.
 		return nil, err
 	}
 	logger.Infof("acquired metadata lock: %s", mdl.lockName)

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -88,7 +88,7 @@ func NewMetadataLock(ctx context.Context, dsn string, table *table.TableInfo, lo
 	if err = getLock(); err != nil {
 		return nil, err
 	}
-	logger.Infof("acquired metadata lock: %s.%s", table.SchemaName, table.TableName)
+	logger.Infof("acquired metadata lock: %s", mdl.lockName)
 
 	// Setup background refresh runner
 	ctx, mdl.cancel = context.WithCancel(ctx)
@@ -100,7 +100,7 @@ func NewMetadataLock(ctx context.Context, dsn string, table *table.TableInfo, lo
 			select {
 			case <-ctx.Done():
 				// Close the dedicated connection to release the lock
-				logger.Warnf("releasing metadata lock for %s", mdl.lockName)
+				logger.Infof("releasing metadata lock: %s", mdl.lockName)
 				mdl.closeCh <- mdl.db.Close()
 				return
 			case <-ticker.C:
@@ -131,7 +131,7 @@ func NewMetadataLock(ctx context.Context, dsn string, table *table.TableInfo, lo
 						continue
 					}
 
-					logger.Infof("re-acquired metadata lock after re-establishing connection: %s.%s", table.SchemaName, table.TableName)
+					logger.Infof("re-acquired metadata lock after re-establishing connection: %s", mdl.lockName)
 				} else {
 					logger.Debugf("refreshed metadata lock for %s", mdl.lockName)
 				}
@@ -178,6 +178,5 @@ func computeLockName(table *table.TableInfo) string {
 	hash.Write([]byte(table.SchemaName + table.TableName))
 	hashPart := hex.EncodeToString(hash.Sum(nil))[:8]
 
-	lockName := fmt.Sprintf("%s.%s-%s", schemaNamePart, tableNamePart, hashPart)
-	return lockName
+	return fmt.Sprintf("%s.%s-%s", schemaNamePart, tableNamePart, hashPart)
 }

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -61,13 +61,13 @@ func TestMetadataLockRefresh(t *testing.T) {
 
 	mdl, err := NewMetadataLock(t.Context(), testutils.DSN(), &lockTableInfo, logger, func(mdl *MetadataLock) {
 		// override the refresh interval for faster testing
-		mdl.refreshInterval = 2 * time.Second
+		mdl.refreshInterval = 1 * time.Second
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, mdl)
 
 	// wait for the refresh to happen
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Confirm the lock is still held
 	_, err = NewMetadataLock(t.Context(), testutils.DSN(), &lockTableInfo, logger)
@@ -105,9 +105,10 @@ func TestMetadataLockLength(t *testing.T) {
 
 	logger := logrus.New()
 
-	_, err := NewMetadataLock(t.Context(), testutils.DSN(), &lockTableInfo, logger)
+	mdl, err := NewMetadataLock(t.Context(), testutils.DSN(), &lockTableInfo, logger)
 	// No error anymore after using a hash of the table name
 	assert.NoError(t, err)
+	defer mdl.Close()
 
 	_, err = NewMetadataLock(t.Context(), testutils.DSN(), empty, logger)
 	assert.ErrorContains(t, err, "metadata lock table info is nil")

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -6,11 +6,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/siddontang/loggers"
-
 	"github.com/cashapp/spirit/pkg/dbconn"
 	"github.com/cashapp/spirit/pkg/repl"
 	"github.com/cashapp/spirit/pkg/table"
+	"github.com/siddontang/loggers"
 )
 
 type CutOver struct {

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -36,6 +36,7 @@ func TestCutOver(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 	assert.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "cutovert1")
@@ -50,6 +51,7 @@ func TestCutOver(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	// the feed must be started.
 	assert.NoError(t, feed.Run())
 
@@ -98,6 +100,7 @@ func TestMDLLockFails(t *testing.T) {
 
 	db, err := dbconn.New(testutils.DSN(), config)
 	assert.NoError(t, err)
+	defer db.Close()
 
 	t1 := table.NewTableInfo(db, "test", "mdllocks")
 	assert.NoError(t, t1.SetInfo(t.Context())) // required to extract PK.
@@ -111,6 +114,7 @@ func TestMDLLockFails(t *testing.T) {
 		Concurrency:     4,
 		TargetBatchTime: time.Second,
 	})
+	defer feed.Close()
 	// the feed must be started.
 	assert.NoError(t, feed.Run())
 
@@ -135,6 +139,7 @@ func TestMDLLockFails(t *testing.T) {
 func TestInvalidOptions(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	assert.NoError(t, err)
+	defer db.Close()
 	logger := logrus.New()
 
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS invalid_t1, _invalid_t1_new`)

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 
@@ -22,6 +23,7 @@ func TestMain(m *testing.M) {
 	statusInterval = 10 * time.Millisecond // the status will be accurate to 1ms
 	sentinelCheckInterval = 100 * time.Millisecond
 	sentinelWaitLimit = 10 * time.Second
+	goleak.VerifyTestMain(m)
 	os.Exit(m.Run())
 }
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -24,21 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type migrationState int32
-
-const (
-	stateInitial migrationState = iota
-	stateCopyRows
-	stateWaitingOnSentinelTable
-	stateApplyChangeset // first mass apply
-	stateAnalyzeTable
-	stateChecksum
-	statePostChecksum // second mass apply
-	stateCutOver
-	stateClose
-	stateErrCleanup
-)
-
 // These are really consts, but set to var for testing.
 var (
 	checkpointDumpInterval  = 50 * time.Second
@@ -47,32 +32,6 @@ var (
 	sentinelCheckInterval   = 1 * time.Second
 	sentinelWaitLimit       = 48 * time.Hour
 )
-
-func (s migrationState) String() string {
-	switch s {
-	case stateInitial:
-		return "initial"
-	case stateCopyRows:
-		return "copyRows"
-	case stateWaitingOnSentinelTable:
-		return "waitingOnSentinelTable"
-	case stateApplyChangeset:
-		return "applyChangeset"
-	case stateAnalyzeTable:
-		return "analyzeTable"
-	case stateChecksum:
-		return "checksum"
-	case statePostChecksum:
-		return "postChecksum"
-	case stateCutOver:
-		return "cutOver"
-	case stateClose:
-		return "close"
-	case stateErrCleanup:
-		return "errCleanup"
-	}
-	return "unknown"
-}
 
 type Runner struct {
 	migration       *Migration

--- a/pkg/migration/state.go
+++ b/pkg/migration/state.go
@@ -1,0 +1,42 @@
+package migration
+
+type migrationState int32
+
+const (
+	stateInitial migrationState = iota
+	stateCopyRows
+	stateWaitingOnSentinelTable
+	stateApplyChangeset // first mass apply
+	stateAnalyzeTable
+	stateChecksum
+	statePostChecksum // second mass apply
+	stateCutOver
+	stateClose
+	stateErrCleanup
+)
+
+func (s migrationState) String() string {
+	switch s {
+	case stateInitial:
+		return "initial"
+	case stateCopyRows:
+		return "copyRows"
+	case stateWaitingOnSentinelTable:
+		return "waitingOnSentinelTable"
+	case stateApplyChangeset:
+		return "applyChangeset"
+	case stateAnalyzeTable:
+		return "analyzeTable"
+	case stateChecksum:
+		return "checksum"
+	case statePostChecksum:
+		return "postChecksum"
+	case stateCutOver:
+		return "cutOver"
+	case stateClose:
+		return "close"
+	case stateErrCleanup:
+		return "errCleanup"
+	}
+	return "unknown"
+}

--- a/pkg/migration/state_test.go
+++ b/pkg/migration/state_test.go
@@ -1,0 +1,19 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigrationStateString(t *testing.T) {
+	assert.Equal(t, "initial", stateInitial.String())
+	assert.Equal(t, "copyRows", stateCopyRows.String())
+	assert.Equal(t, "waitingOnSentinelTable", stateWaitingOnSentinelTable.String())
+	assert.Equal(t, "applyChangeset", stateApplyChangeset.String())
+	assert.Equal(t, "checksum", stateChecksum.String())
+	assert.Equal(t, "cutOver", stateCutOver.String())
+	assert.Equal(t, "errCleanup", stateErrCleanup.String())
+	assert.Equal(t, "analyzeTable", stateAnalyzeTable.String())
+	assert.Equal(t, "close", stateClose.String())
+}

--- a/pkg/migration/testlogger.go
+++ b/pkg/migration/testlogger.go
@@ -1,0 +1,40 @@
+package migration
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type testLogger struct {
+	sync.Mutex
+	logrus.FieldLogger
+	lastInfof  string
+	lastWarnf  string
+	lastDebugf string
+}
+
+func (l *testLogger) Infof(format string, args ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	l.lastInfof = fmt.Sprintf(format, args...)
+}
+
+func (l *testLogger) Warnf(format string, args ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	l.lastWarnf = fmt.Sprintf(format, args...)
+}
+
+func (l *testLogger) Debugf(format string, args ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	l.lastDebugf = fmt.Sprintf(format, args...)
+}
+
+func newTestLogger() *testLogger {
+	return &testLogger{
+		FieldLogger: logrus.New(),
+	}
+}

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -105,6 +105,7 @@ type Client struct {
 	concurrency     int
 
 	isMySQL84 bool
+	isRunning bool
 
 	// The periodic flush lock is just used for ensuring only one periodic flush runs at a time,
 	// and when we disable it, no more periodic flushes will run. The actual flushing is protected
@@ -289,6 +290,13 @@ func (c *Client) getCurrentBinlogPosition() (mysql.Position, error) {
 }
 
 func (c *Client) Run() (err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.isRunning {
+		return errors.New("Run() has already been called")
+	}
+	c.isRunning = true
+
 	// We have to disable the delta map
 	// if the primary key is *not* memory comparable.
 	// We use a FIFO queue instead.

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -1,11 +1,17 @@
 package statement
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+	os.Exit(m.Run())
+}
 func TestExtractFromStatement(t *testing.T) {
 	abstractStmt, err := New("ALTER TABLE t1 ADD INDEX (something)")
 	assert.NoError(t, err)

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -2,15 +2,22 @@ package table
 
 import (
 	"database/sql"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/cashapp/spirit/pkg/testutils"
+	"go.uber.org/goleak"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+	os.Exit(m.Run())
+}
 
 func TestOpenOnBinaryType(t *testing.T) {
 	t1 := NewTableInfo(nil, "test", "t1")
@@ -235,6 +242,7 @@ func TestDiscoveryCompositeComparable(t *testing.T) {
 func TestStatisticsUpdate(t *testing.T) {
 	db, err := sql.Open("mysql", testutils.DSN())
 	assert.NoError(t, err)
+	defer db.Close()
 
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS statsupdate`)
 	table := `CREATE TABLE statsupdate (

--- a/pkg/throttler/mysql80replica.go
+++ b/pkg/throttler/mysql80replica.go
@@ -71,7 +71,7 @@ func (l *MySQL80Replica) Close() error {
 // It requires performance_schema to be enabled.
 func (l *MySQL80Replica) UpdateLag() error {
 	var newLagValue int64
-	if err := l.replica.QueryRow(MySQL8LagQuery).Scan(&newLagValue); err != nil { //nolint: execinquery
+	if err := l.replica.QueryRow(MySQL8LagQuery).Scan(&newLagValue); err != nil {
 		return errors.New("could not check replication lag, check that this is a MySQL 8.0 replica, and that performance_schema is enabled")
 	}
 	atomic.StoreInt64(&l.currentLagInMs, newLagValue)

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -7,10 +7,16 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"go.uber.org/goleak"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+	os.Exit(m.Run())
+}
 
 func TestThrottlerInterface(t *testing.T) {
 	replicaDSN := os.Getenv("REPLICA_DSN")
@@ -19,6 +25,7 @@ func TestThrottlerInterface(t *testing.T) {
 	}
 	db, err := sql.Open("mysql", replicaDSN)
 	assert.NoError(t, err)
+	defer db.Close()
 
 	//	NewReplicationThrottler will attach either MySQL 8.0 or MySQL 5.7 throttler
 	loopInterval = 1 * time.Millisecond

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,12 +1,19 @@
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/cashapp/spirit/pkg/table"
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+	os.Exit(m.Run())
+}
 
 func TestIntersectColumns(t *testing.T) {
 	t1 := table.NewTableInfo(nil, "test", "t1")


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/cashapp/spirit/blob/main/.github/CONTRIBUTING.md

This pulls out the unrelated changes from https://github.com/cashapp/spirit/pull/389

- We didn't have leak detection on tests, this meant some leaked.
- Some left over linter ignores can be removed.
- Small moves of functions to separate files
- Fix the logging messages in metadatalock to be consistent.
