### PR TITLE
exclude generated columns from checksum

### DIFF
--- a/pkg/checksum/checker.go
+++ b/pkg/checksum/checker.go
@@ -446,8 +446,8 @@ func (c *Checker) Run(ctx context.Context) error {
 // The cast is to c.newTable type.
 func (c *Checker) intersectColumns() string {
 	var intersection []string
-	for _, col := range c.table.Columns {
-		for _, col2 := range c.newTable.Columns {
+	for _, col := range c.table.NonGeneratedColumns {
+		for _, col2 := range c.newTable.NonGeneratedColumns {
 			if col == col2 {
 				// Column exists in both, so we add intersection wrapped in
 				// IFNULL, ISNULL and CAST.

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -330,4 +330,24 @@ func TestDiscoveryGeneratedCols(t *testing.T) {
 	// Can't check estimated rows (depends on MySQL version etc)
 	assert.Equal(t, []string{"id", "name", "b", "c1", "c2", "c3", "d"}, t1.Columns)
 	assert.Equal(t, []string{"id", "name", "b", "d"}, t1.NonGeneratedColumns)
+
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS generatedcolst2`)
+	table = `CREATE TABLE generatedcolst2 (
+  id bigint NOT NULL AUTO_INCREMENT,
+  pa bigint DEFAULT NULL,
+  p1 bigint DEFAULT NULL,
+  p2 bigint DEFAULT NULL,
+  s1 tinyint(1) GENERATED ALWAYS AS (if((pa is not null),1,NULL)) STORED,
+  s2 tinyint(1) GENERATED ALWAYS AS (if((p1 is not null),1,NULL)) STORED,
+  s3 tinyint(1) GENERATED ALWAYS AS (if((p2 is not null),1,NULL)) STORED,
+  s4 tinyint(1) GENERATED ALWAYS AS (if((pa <> p2),1,NULL)) STORED,
+  PRIMARY KEY (id)
+);`
+	testutils.RunSQL(t, table)
+	t2 := NewTableInfo(db, "test", "generatedcolst2")
+	assert.NoError(t, t2.SetInfo(t.Context()))
+
+	// Can't check estimated rows (depends on MySQL version etc)
+	assert.Equal(t, []string{"id", "pa", "p1", "p2", "s1", "s2", "s3", "s4"}, t2.Columns)
+	assert.Equal(t, []string{"id", "pa", "p1", "p2"}, t2.NonGeneratedColumns)
 }


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

The previous fix for https://github.com/cashapp/spirit/pull/324 was incomplete.

It excluded generated columns from the copier (from table to new table), but it didn't exclude them from the checksum. If the generated column existed in original and new, but the definition changed, then it could fail to validate the checksum.

The fix for this is simple - use the same exclusion of generated columns for comparison.

Fixes https://github.com/cashapp/spirit/issues/395