### PR TITLE
Support add partition. Fix syntax errors for partition statements.

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -592,11 +592,11 @@ func (r *Runner) oldTableName() string {
 }
 
 func (r *Runner) attemptInstantDDL(ctx context.Context) error {
-	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n "+r.stmt.Alter+", ALGORITHM=INSTANT", r.table.SchemaName, r.table.TableName)
+	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n ALGORITHM=INSTANT, "+r.stmt.Alter, r.table.SchemaName, r.table.TableName)
 }
 
 func (r *Runner) attemptInplaceDDL(ctx context.Context) error {
-	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n "+r.stmt.Alter+", ALGORITHM=INPLACE, LOCK=NONE", r.table.SchemaName, r.table.TableName)
+	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n ALGORITHM=INPLACE, LOCK=NONE, "+r.stmt.Alter, r.table.SchemaName, r.table.TableName)
 }
 
 func (r *Runner) createCheckpointTable(ctx context.Context) error {

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -147,7 +147,8 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 			ast.AlterTableRenameIndex,
 			ast.AlterTableIndexInvisible,
 			ast.AlterTableDropPartition,
-			ast.AlterTableTruncatePartition:
+			ast.AlterTableTruncatePartition,
+			ast.AlterTableAddPartitions:
 			continue
 		default:
 			unsafeClauses++

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -104,6 +104,8 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	assert.NoError(t, test("ALTER INDEX b VISIBLE"))
 	assert.NoError(t, test("drop partition `p1`, `p2`"))
 	assert.NoError(t, test("truncate partition `p1`, `p3`"))
+	assert.NoError(t, test("add partition (partition `p1` values less than (100))"))
+	assert.NoError(t, test("add partition partitions 4"))
 
 	assert.Error(t, test("ADD COLUMN `a` INT"))
 	assert.Error(t, test("ADD index (a)"))
@@ -114,6 +116,7 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	// guess which operations are INSTANT
 	assert.Error(t, test("drop index `a`, add column `b` int"))
 	assert.Error(t, test("ALTER INDEX b INVISIBLE, add column `c` int"))
+	assert.Error(t, test("remove partitioning"))
 }
 
 func TestAlterIsAddUnique(t *testing.T) {


### PR DESCRIPTION
This follows https://github.com/cashapp/spirit/pull/387 and fixes https://github.com/cashapp/spirit/issues/383. 

`DROP PARTITION` and `TRUNCATE PARTITION` statements require that `algorithm` and `lock` statements are placed before the partition statement and after the alter statement. Otherwise, the syntax is incorrect and the operation will fail. This PR also allows `ADD PARTITION` since it can be performed safely inplace without a lock for range/list partitioned tables. The operation fails with a mysql syntax error when tried on a hash/key partitioned table preventing an unsafe DDL.